### PR TITLE
Add mailer configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ PG_PASSWORD=postgres
 
 # Appsignal push API key
 APPSIGNAL_PUSH_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Configuration for sending emails
+MAILER_DOMAIN=xxxxxxxxxx
+MAILER_ADDRESS=xxxxxxxxxx
+MAILER_USERNAME=xxxxxxxxxx
+MAILER_PASSWORD=xxxxxxxxxx
+MAILER_HOST=xxxxxxxxxx

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,4 @@ MAILER_ADDRESS=xxxxxxxxxx
 MAILER_USERNAME=xxxxxxxxxx
 MAILER_PASSWORD=xxxxxxxxxx
 MAILER_HOST=xxxxxxxxxx
+MAILER_FROM=no-reply@unep-wcmc.org

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ group :development do
   gem 'capistrano-rvm',   '~> 0.1', require: false
   gem 'capistrano-passenger', '~> 0.2.0', require: false
 
-
+  # Mailer
+  gem 'letter_opener'
 
 
 end

--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,6 @@ gem 'web-console', '~> 2.0', group: :development
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.4'
-  gem 'factory_girl_rails'
-  gem 'faker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     airbrussh (1.0.2)
       sshkit (>= 1.6.1, != 1.7.0)
     akami (1.3.1)
@@ -120,6 +121,10 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.0.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -264,6 +269,7 @@ DEPENDENCIES
   faker
   font-awesome-rails
   jquery-rails
+  letter_opener
   pg (~> 0.18.4)
   rails (~> 5.0.0)
   redcarpet (~> 3.3.4)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,2 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@epix.org'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,13 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: Rails.application.secrets.mailer['host'] }
+
+  config.action_mailer.default_options = {
+    from: Rails.application.secrets.mailer['from']
+  }
+
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,10 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: Rails.application.secrets.mailer['host'] }
 
+  config.action_mailer.default_options = {
+    from: Rails.application.secrets.mailer['from']
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,18 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.smtp_settings = {
+    domain: Rails.application.secrets.mailer['domain'],
+    address: Rails.application.secrets.mailer['address'],
+    port: 587,
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: Rails.application.secrets.mailer['username'],
+    password: Rails.application.secrets.mailer['password']
+  }
+
+  config.action_mailer.default_url_options = { host: Rails.application.secrets.mailer['host'] }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -76,6 +76,9 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: Rails.application.secrets.mailer['host'] }
 
+  config.action_mailer.default_options = {
+    from: Rails.application.secrets.mailer['from']
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,7 +63,19 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: 'https://epix-staging.linode.unep-wcmc.org/' }
+
+  config.action_mailer.smtp_settings = {
+    domain: Rails.application.secrets.mailer['domain'],
+    address: Rails.application.secrets.mailer['address'],
+    port: 587,
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: Rails.application.secrets.mailer['username'],
+    password: Rails.application.secrets.mailer['password']
+  }
+
+  config.action_mailer.default_url_options = { host: Rails.application.secrets.mailer['host'] }
+
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+    config.action_mailer.default_options = {
+    from: 'no-reply@epix.org'
+  }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,7 +1,13 @@
 default: &default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  mailer:
+    domain: <%= ENV["MAILER_DOMAIN"] %>
+    address: <%= ENV["MAILER_ADDRESS"] %>
+    username: <%= ENV["MAILER_USERNAME"] %>
+    password: <%= ENV["MAILER_PASSWORD"] %>
+    host: <%= ENV["MAILER_HOST"] %>
 
-production_and_staging_default: &production_and_staging_default
+production_and_staging: &production_and_staging
   <<: *default
   adapter:
     auth_token_key: <%= ENV["ENCRYPTION_KEY"] %>
@@ -23,10 +29,7 @@ test:
   <<: *default
 
 production:
-  <<: *production_and_staging_default
-
+  <<: *production_and_staging
 
 staging:
-  <<: *production_and_staging_default
-
-
+  <<: *production_and_staging

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,6 +6,7 @@ default: &default
     username: <%= ENV["MAILER_USERNAME"] %>
     password: <%= ENV["MAILER_PASSWORD"] %>
     host: <%= ENV["MAILER_HOST"] %>
+    from: <%= ENV["MAILER_FROM"] %>
 
 production_and_staging: &production_and_staging
   <<: *default


### PR DESCRIPTION
Added smtp mailer configuration for staging & production and letter opener gem to preview emails in development. To configure in development you'll need to set `MAILER_HOST` and `MAILER_FROM` in your `.env` file.
