### PR TITLE
Add edit organisations

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -7,3 +7,4 @@
 @import "shared/layout";
 @import "shared/components";
 @import "admin/users";
+@import "admin/organisations";

--- a/app/assets/stylesheets/admin/organisations.scss
+++ b/app/assets/stylesheets/admin/organisations.scss
@@ -1,0 +1,3 @@
+.organisation-details {
+  padding: 30px 0;
+}

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -37,13 +37,6 @@ class Admin::OrganisationsController < Admin::BaseController
     respond_with :admin, @organisation
   end
 
-  def destroy
-    @organisation = Organisation.find(params[:id])
-    flash[:notice] = 'Organisation was successfully deleted' if @organisation.destroy
-
-    respond_with :admin, @organisation
-  end
-
   private
 
   def organisation_params

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -30,7 +30,7 @@ class Admin::OrganisationsController < Admin::BaseController
   def update
     @organisation = Organisation.find(params[:id])
 
-    if @organisation.update_attributes(user_params)
+    if @organisation.update_attributes(organisation_params)
       flash[:notice] = 'Organisation was successfully updated.'
     end
 

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,60 @@
 class Admin::OrganisationsController < Admin::BaseController
+  respond_to :html
+
+  before_action :format_organisations
+  before_action :load_countries
+
   def index
     @organisations = Organisation.select(
       :id, :name, :role, :country_id
     )
+  end
+
+  def new
+    @organisation = Organisation.new
+  end
+
+  def edit
+    @organisation = Organisation.find(params[:id])
+    @adapter = @organisation.try(:adapter)
+  end
+
+  def create
+    @organisation = Organisation.new(organisation_params)
+
+    flash[:notice] = 'Organisation was successfully created' if @organisation.save
+
+    respond_with :admin, @organisation
+  end
+
+  def update
+    @organisation = Organisation.find(params[:id])
+
+    if @organisation.update_attributes(user_params)
+      flash[:notice] = 'Organisation was successfully updated.'
+    end
+
+    respond_with :admin, @organisation
+  end
+
+  def destroy
+    @organisation = Organisation.find(params[:id])
+    flash[:notice] = 'Organisation was successfully deleted' if @organisation.destroy
+
+    respond_with :admin, @organisation
+  end
+
+  private
+
+  def organisation_params
+    params.require(:organisation).permit(:name, :role, :country_id)
+  end
+
+  def format_organisations
+    @organisations_for_dropdown = Organisation.all.map { |o| [o.name, o.id] }
+  end
+
+  def load_countries
+    @countries_for_dropdown = Country.all.map { |c| [c.name, c.id] }
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,7 @@ class Organisation < ApplicationRecord
   OTHER = 'Other'
   VALID_ROLES = [CITES_MA, CUSTOMS_EA, SYSTEM_MANAGERS, OTHER]
   validates :name, :role, :country, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: {scope: [:country, :role]}
   validates_inclusion_of :role, in: VALID_ROLES
 
   def display_name

--- a/app/views/admin/organisations/_buttons.html.erb
+++ b/app/views/admin/organisations/_buttons.html.erb
@@ -1,0 +1,4 @@
+<div class="buttons">
+  <%= link_to 'Cancel', admin_organisations_path, class: 'button btn-scnd' %>
+  <input type="submit" value="Submit" form=<%= form_id %> class='button'>
+</div>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_for @organisation, url: {action: action}, html: {id: form_id, class: 'form-horizontal'} do |f| %>
+  <div class="organisation-details">
+    <div class="form-group">
+      <%= f.label :name, class: 'col-sm-3 control-label' %>
+      <div class="col-sm-4">
+        <%= f.text_field :name, value: @organisation.name, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :role, class: 'col-sm-3 control-label' %>
+      <div class="col-sm-4">
+        <%= f.select :role,
+          options_for_select(Organisation::VALID_ROLES, @organisation.try(:role)),
+          {}, class: "form-control"
+        %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :country_id, class: 'col-sm-3 control-label' %>
+      <div class="col-sm-4">
+        <%= f.select :country_id,
+          options_for_select(@countries_for_dropdown, @country.try(:id)),
+          {}, class: "form-control"
+        %>
+      </div>
+    </div>
+  </div>
+<% end %> <!-- End Form -->

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -1,3 +1,7 @@
+<% @organisation.errors.full_messages.each do |message| %>
+  <%= content_tag :div, message, class: "alert alert-notice" %>
+<% end %>
+
 <%= form_for @organisation, url: {action: action}, html: {id: form_id, class: 'form-horizontal'} do |f| %>
   <div class="organisation-details">
     <div class="form-group">

--- a/app/views/admin/organisations/edit.html.erb
+++ b/app/views/admin/organisations/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="form-header">
+  <h2>Edit organisation</h2>
+  <%= render partial: "buttons", locals: {form_id: "organisation_edit_form"} %>
+</div>
+
+<%= render partial: "form", locals: {action: "update", form_id: "organisation_edit_form"} %>
+
+<h3>Web Service details</h3>
+<div class="web-service-details form-horizontal">
+  <div class="form-group">
+    <label class='col-sm-3'>Status</label>
+    <span class='col-sm-3'>
+      <%= check_box_tag :status, 'is_available',  @adapter.try(:is_available),  disabled: true %>
+      <%= @adapter.try(:is_available)? "Up" : "Down" %>
+    </span>
+  </div>
+  <div class="form-group">
+    <label class='col-sm-3'>URI</label>
+    <span class='col-sm-5'><%= @adapter.try(:web_service_uri) %></span>
+  </div>
+</div>
+
+<div class="form-footer">
+  <%= render partial: "buttons", locals: {form_id: "organisation_edit_form"} %>
+</div>

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="list-header">
   <h2>Organisations</h2>
   <div class="buttons">
-    <%= link_to 'Add organisation', '#', class: 'button' %>
+    <%= link_to 'Add organisation', new_admin_organisation_path , class: 'button' %>
   </div>
 </div>
 
@@ -36,7 +36,7 @@
         </td>
         <td>
           <%= link_to(
-            '#',
+            admin_organisation_path(organisation),
             method: :delete,
             data: { confirm: t('delete_are_you_sure') }){ fa_icon "trash" }
           %>

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -32,7 +32,7 @@
           <%= organisation.country && organisation.country.name %>
         </td>
         <td>
-          <%= link_to('#') { fa_icon "pencil" } %>
+          <%= link_to(edit_admin_organisation_path(organisation)) { fa_icon "pencil" } %>
         </td>
         <td>
           <%= link_to(

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -13,7 +13,6 @@
       <th class='searchable'><%= t('organisation_role') %></th>
       <th class='searchable'><%= t('organisation_country') %></th>
       <th class="no-sort"></th>
-      <th class="no-sort"></th>
     </tr>
   </thead>
   <tbody>
@@ -34,13 +33,6 @@
         <td>
           <%= link_to(edit_admin_organisation_path(organisation)) { fa_icon "pencil" } %>
         </td>
-        <td>
-          <%= link_to(
-            admin_organisation_path(organisation),
-            method: :delete,
-            data: { confirm: t('delete_are_you_sure') }){ fa_icon "trash" }
-          %>
-        </td>
       </tr>
     <% end %>
   </tbody>
@@ -50,7 +42,6 @@
       <th><input type="text" placeholder="Search name" ></th>
       <th><input type="text" placeholder="Search role" ></th>
       <th><input type="text" placeholder="Search country" /></th>
-      <th class="no-sort"></th>
       <th class="no-sort"></th>
     </tr>
   </tfoot>

--- a/app/views/admin/organisations/new.html.erb
+++ b/app/views/admin/organisations/new.html.erb
@@ -1,0 +1,10 @@
+<div class="form-header">
+  <h2>New organisation</h2>
+  <%= render partial: "buttons", locals: {form_id: "new_organisation_form"} %>
+</div>
+
+<%= render partial: "form", locals: {action: "create", form_id: "new_organisation_form"} %>
+
+<div class="form-footer">
+  <%= render partial: "buttons", locals: {form_id: "new_organisation_form"} %>
+</div>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Show page</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :permits, only: [:index]
 
   namespace :admin do
-    resources :organisations, only: [:index]
+    resources :organisations
     resources :users
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :permits, only: [:index]
 
   namespace :admin do
-    resources :organisations
+    resources :organisations, except: [:destroy]
     resources :users
   end
 

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -7,4 +7,62 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
       expect(response.status).to eq(200)
     end
   end
+
+  describe "GET new" do
+    it "has a 200 status code" do
+      get :new
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "GET edit" do
+    it "has a 200 status code" do
+      get :edit, id: FactoryGirl.create(:organisation).id
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "GET show" do
+    it "has a 200 status code" do
+      get :show, id: FactoryGirl.create(:organisation).id
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "POST create" do
+    it "creates a organisation" do
+      expect do
+        post :create, params: {
+          organisation: {
+            name: 'org_name',
+            role: 'CITES MA',
+            country_id: FactoryGirl.create(:country).id
+          }
+        }
+      end.to change{ Organisation.count }
+
+      expect(response.status).to eq(302)
+    end
+  end
+
+  describe "PATCH update" do
+    it "updates a organisation" do
+      organisation = FactoryGirl.create(:organisation)
+      patch :update, id: organisation.id, organisation: { name: 'asd'}
+      organisation.reload
+      expect(organisation.name).to eq('asd')
+      expect(response.status).to eq(302)
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "destroys a organisation" do
+      organisation = FactoryGirl.create(:organisation)
+      expect do
+        delete :destroy, id: organisation.id
+      end.to change{ Organisation.count }
+
+      expect(response.status).to eq(302)
+    end
+  end
 end

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -54,15 +54,4 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
       expect(response.status).to eq(302)
     end
   end
-
-  describe "DELETE destroy" do
-    it "destroys a organisation" do
-      organisation = FactoryGirl.create(:organisation)
-      expect do
-        delete :destroy, id: organisation.id
-      end.to change{ Organisation.count }
-
-      expect(response.status).to eq(302)
-    end
-  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Organisation, type: :model do
+  let(:switzerland){
+    FactoryGirl.create(:country, name: 'Switzerland')
+  }
+
   it "has a valid role" do
     expect(FactoryGirl.build(:organisation)).to be_valid
   end
@@ -11,8 +15,13 @@ RSpec.describe Organisation, type: :model do
   end
 
   it "has an invalid name" do
-    FactoryGirl.create(:organisation, name: 'org')
-    expect(FactoryGirl.build(:organisation, name: 'org')).to be_invalid
+    organisation_attributes = {
+      name: 'Ministry of Environment',
+      country: switzerland,
+      role: Organisation::CITES_MA
+    }
+    FactoryGirl.create(:organisation, organisation_attributes)
+    expect(FactoryGirl.build(:organisation, organisation_attributes)).to be_invalid
   end
 
   it "is invalid without name" do
@@ -28,9 +37,6 @@ RSpec.describe Organisation, type: :model do
   end
 
   describe :display_name do
-    let(:switzerland){
-      FactoryGirl.create(:country, name: 'Switzerland')
-    }
     let(:swiss_ma){
       FactoryGirl.create(:organisation, role: Organisation::CITES_MA, country: switzerland)
     }


### PR DESCRIPTION
Adds the functionality of creating and editing organisations.
Deleting an organisation through the delete icon in the index page is possible as well.
I didn't include the ability to change the related adapters information since I think it should be something to achieve at a later stage, when implementing roles and permissions
