### PR TITLE
Improvements for loading dropdowns

### DIFF
--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,6 +1,6 @@
 table.dataTable td, table.dataTable th { padding: 0px 2px }
 
-.organisation-role, .organisation-token {
+.organisation-name, .organisation-token {
   display: none;
   &.selected-org { display: block; }
 }

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,6 @@
 class Admin::OrganisationsController < Admin::BaseController
   respond_to :html
 
-  before_action :format_organisations
   before_action :load_countries
 
   def index
@@ -41,10 +40,6 @@ class Admin::OrganisationsController < Admin::BaseController
 
   def organisation_params
     params.require(:organisation).permit(:name, :role, :country_id)
-  end
-
-  def format_organisations
-    @organisations_for_dropdown = Organisation.all.map { |o| [o.name, o.id] }
   end
 
   def load_countries

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrganisationsController < Admin::BaseController
   respond_to :html
 
-  before_action :load_countries
+  before_action :load_countries_for_dropdown, only: [:new, :create, :edit, :update]
 
   def index
     @organisations = Organisation.select(
@@ -42,7 +42,10 @@ class Admin::OrganisationsController < Admin::BaseController
     params.require(:organisation).permit(:name, :role, :country_id)
   end
 
-  def load_countries
-    @countries_for_dropdown = Country.all.map { |c| [c.name, c.id] }
+  def load_countries_for_dropdown
+    @countries_for_dropdown = Country.select(
+      :id, :name
+    ).
+    order(:name).map { |c| [c.name, c.id] }
   end
 end

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -4,7 +4,7 @@ class Admin::OrganisationsController < Admin::BaseController
   before_action :load_countries_for_dropdown, only: [:new, :create, :edit, :update]
 
   def index
-    @organisations = Organisation.select(
+    @organisations = Organisation.includes(:country).select(
       :id, :name, :role, :country_id
     )
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -60,10 +60,12 @@ class Admin::UsersController < Admin::BaseController
     end
   end
 
-    @organisations = Organisation.order(:name)
-    @organisations_for_dropdown = @organisations.map { |o| [o.name, o.id] }
-    @organisations_roles = @organisations.map { |o| [o.role, o.id] }
-    @organisations_tokens = @organisations.map { |o| [o.adapter.try(:auth_token), o.id ] }
   def load_organisations_for_dropdown
+    @organisations = Organisation.includes(:country).select(
+      :id, :name, :role, :country_id
+    ).order(:role, 'countries.name', :name)
+    @organisations_for_dropdown = @organisations.map { |o| [o.display_name, o.id] }
+    @organisations_names = @organisations.map { |o| [o.name, o.id] }
+    @organisations_tokens = @organisations.map { |o| [o.adapter.try(:auth_token), o.id ] }
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 class Admin::UsersController < Admin::BaseController
   respond_to :html
 
-  before_action :load_organisations
+  before_action :load_organisations_for_dropdown, only: [:new, :create, :edit, :update]
 
   def index
     @users = User.select(
@@ -60,10 +60,10 @@ class Admin::UsersController < Admin::BaseController
     end
   end
 
-  def load_organisations
     @organisations = Organisation.order(:name)
     @organisations_for_dropdown = @organisations.map { |o| [o.name, o.id] }
     @organisations_roles = @organisations.map { |o| [o.role, o.id] }
     @organisations_tokens = @organisations.map { |o| [o.adapter.try(:auth_token), o.id ] }
+  def load_organisations_for_dropdown
   end
 end

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -14,7 +14,7 @@
       <%= f.label :role, class: 'col-sm-3 control-label' %>
       <div class="col-sm-4">
         <%= f.select :role,
-          options_for_select(Organisation::VALID_ROLES, @organisation.try(:role)),
+          options_for_select(Organisation::VALID_ROLES, @organisation.role),
           {}, class: "form-control"
         %>
       </div>
@@ -23,7 +23,7 @@
       <%= f.label :country_id, class: 'col-sm-3 control-label' %>
       <div class="col-sm-4">
         <%= f.select :country_id,
-          options_for_select(@countries_for_dropdown, @country.try(:id)),
+          options_for_select(@countries_for_dropdown, @organisation.country_id),
           {}, class: "form-control"
         %>
       </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -50,12 +50,12 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-sm-3">Organisation type</label>
+      <label class="col-sm-3">Organisation name</label>
       <div class="col-sm-3">
-        <% @organisations_roles.each do |role, id| %>
-          <span class="organisation-role <%= "org-#{id}" %>
+        <% @organisations_names.each do |name, id| %>
+          <span class="organisation-name <%= "org-#{id}" %>
             <%= 'selected-org' if (@organisation.try(:id) || @organisations.first.id) == id %>">
-            <%= role %>
+            <%= name %>
           </span>
         <% end %>
       </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -45,7 +45,7 @@
       <%= f.label :organisation_id, class: 'col-sm-3 control-label' %>
       <div class="col-sm-4">
         <%= f.select :organisation_id,
-          options_for_select(@organisations_for_dropdown, @organisation.try(:id)), {}, class: "form-control chained-select"
+          options_for_select(@organisations_for_dropdown, @user.organisation_id), {}, class: "form-control chained-select"
         %>
       </div>
     </div>


### PR DESCRIPTION
Small improvements to keep the logic for loading content of drop downs consistent between users & organisations controllers and avoid unnecessary loading.

The only functional change is that in the user form the organisations drop down shows organisation `display_name`, rather than `name`. That is because in case of CITES MAs and possibly Customs the name might not be informative enough (e.g. "Ministry of Environment") and for those types of organisations a combination of role + country is displayed instead.
