### PR TITLE
ensure organisation role is unique in scope of country

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,8 @@ class Organisation < ApplicationRecord
   OTHER = 'Other'
   VALID_ROLES = [CITES_MA, CUSTOMS_EA, SYSTEM_MANAGERS, OTHER]
   validates :name, :role, :country, presence: true
-  validates :name, uniqueness: {scope: [:country, :role]}
+  validates :name, uniqueness: {scope: :country}
+  validates :role, uniqueness: {scope: :country}
   validates_inclusion_of :role, in: VALID_ROLES
 
   def display_name

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -14,11 +14,19 @@ RSpec.describe Organisation, type: :model do
     expect(organisation).to be_invalid
   end
 
-  it "has an invalid name" do
+  it "is a duplicate (role within country)" do
     organisation_attributes = {
-      name: 'Ministry of Environment',
       country: switzerland,
       role: Organisation::CITES_MA
+    }
+    FactoryGirl.create(:organisation, organisation_attributes)
+    expect(FactoryGirl.build(:organisation, organisation_attributes)).to be_invalid
+  end
+
+  it "is a duplicate (name within role & country)" do
+    organisation_attributes = {
+      name: 'Ministry of Environment',
+      country: switzerland
     }
     FactoryGirl.create(:organisation, organisation_attributes)
     expect(FactoryGirl.build(:organisation, organisation_attributes)).to be_invalid


### PR DESCRIPTION
To ensure we don't have multiple CITES MAs in same country.
