### PR TITLE
Roles and permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,4 +58,5 @@ group :test do
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'database_cleaner'
+  gem 'rails-controller-testing'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'devise'
 gem 'savon'
 
 gem 'attr_encrypted', '~>3.0.0'
+gem 'cancancan', '~> 1.10'
 
 group :development do
   # Docs

--- a/Gemfile
+++ b/Gemfile
@@ -57,4 +57,5 @@ group :test do
   gem 'codeclimate-test-reporter', require: false
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (9.0.5)
+    cancancan (1.15.0)
     capistrano (3.5.0)
       airbrussh (>= 1.0.0)
       capistrano-harrow
@@ -256,6 +257,7 @@ DEPENDENCIES
   appsignal (~> 1.1.9)
   attr_encrypted (~> 3.0.0)
   byebug
+  cancancan (~> 1.10)
   capistrano (~> 3.4)
   capistrano-bundler (~> 1.1)
   capistrano-passenger (~> 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     devise (4.2.0)
       bcrypt (~> 3.0)
@@ -265,6 +266,7 @@ DEPENDENCIES
   capistrano-rvm (~> 0.1)
   codeclimate-test-reporter
   coffee-rails (~> 4.2.0)
+  database_cleaner
   devise
   dotenv-rails (~> 2.1.1)
   factory_girl_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (0.1.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -276,6 +280,7 @@ DEPENDENCIES
   letter_opener
   pg (~> 0.18.4)
   rails (~> 5.0.0)
+  rails-controller-testing
   redcarpet (~> 3.3.4)
   rspec-rails (~> 3.4)
   sass-rails (~> 5.0)

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,4 +1,5 @@
 class Admin::OrganisationsController < Admin::BaseController
+  load_and_authorize_resource
   respond_to :html
 
   before_action :load_countries_for_dropdown, only: [:new, :create, :edit, :update]
@@ -39,7 +40,11 @@ class Admin::OrganisationsController < Admin::BaseController
   private
 
   def organisation_params
-    params.require(:organisation).permit(:name, :role, :country_id)
+    if current_user.is_system_managers?
+      params.require(:organisation).permit(:name, :role, :country_id)
+    else
+      params.require(:organisation).permit(:name, :country_id)
+    end
   end
 
   def load_countries_for_dropdown

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,6 +9,9 @@ class Admin::UsersController < Admin::BaseController
     @users = User.select(
       :id, :first_name, :last_name, :email, :organisation_id, :is_admin
     )
+    if current_user && !current_user.is_system_managers?
+      @users = @users.where(organisation_id: current_user.organisation_id)
+    end
   end
 
   def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < Admin::BaseController
+  load_and_authorize_resource
+
   respond_to :html
 
   before_action :load_organisations_for_dropdown, only: [:new, :create, :edit, :update]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to root_url, notice: exception.message
+  end
+
   private
 
   def set_locale

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,11 +10,9 @@ class Ability
         can :update, Organisation, id: user.organisation.id
         can :update, Adapter, id: user.organisation.try(:adapter).try(:id)
         can :manage, User, organisation_id: user.organisation_id
-        cannot :index, User
       elsif user.is_customs_ea?
         can :update, Organisation, id: user.organisation.id
         can :manage, User, organisation_id: user.organisation_id
-        cannot :index, User
       else
         can :update, User, id: user.id
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,9 +10,11 @@ class Ability
         can :update, Organisation, id: user.organisation.id
         can :update, Adapter, id: user.organisation.try(:adapter).try(:id)
         can :manage, User, organisation_id: user.organisation_id
+        cannot :index, User
       elsif user.is_customs_ea?
         can :update, Organisation, id: user.organisation.id
         can :manage, User, organisation_id: user.organisation_id
+        cannot :index, User
       else
         can :update, User, id: user.id
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,20 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    if user.is_admin
+      if user.is_system_managers?
+        can :manage, :all
+      elsif user.is_cites_ma?
+        can :update, Organisation, id: user.organisation.id
+        can :update, Adapter, id: user.organisation.adapter.id
+        can :manage, User, organisation_id: user.organisation_id
+      elsif user.is_customs_ea?
+        can :update, Organisation, id: user.organisation.id
+        can :manage, User, organisation_id: user.organisation_id
+      end
+    else
+      can :update, User, id: user.id
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,8 @@ class Ability
       elsif user.is_customs_ea?
         can :update, Organisation, id: user.organisation.id
         can :manage, User, organisation_id: user.organisation_id
+      else
+        can :update, User, id: user.id
       end
     else
       can :update, User, id: user.id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
         can :manage, :all
       elsif user.is_cites_ma?
         can :update, Organisation, id: user.organisation.id
-        can :update, Adapter, id: user.organisation.adapter.id
+        can :update, Adapter, id: user.organisation.try(:adapter).try(:id)
         can :manage, User, organisation_id: user.organisation_id
       elsif user.is_customs_ea?
         can :update, Organisation, id: user.organisation.id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,6 +2,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    user ||= User.new
     if user.is_admin
       if user.is_system_managers?
         can :manage, :all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,12 @@ class User < ApplicationRecord
   def send_welcome_email
     UserMailer.welcome_email(self).deliver_now
   end
+
+  Organisation::VALID_ROLES.each do |role|
+    role_formatted = role.downcase.tr(" ", "_")
+    define_method("is_#{role_formatted}?") do
+      self.organisation.role == role
+    end
+  end
+
 end

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -15,7 +15,7 @@
       <div class="col-sm-4">
         <%= f.select :role,
           options_for_select(Organisation::VALID_ROLES, @organisation.role),
-          {}, class: "form-control"
+          {}, {class: "form-control", disabled: !current_user.is_system_managers? }
         %>
       </div>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,8 +29,12 @@
             </button>
             <ul class="dropdown-menu">
               <li><a href="#">Settings</a></li>
-              <li><%= link_to(t('organisations_list'), admin_organisations_url, 'data-no-turbolink' => true) %></li>
-              <li><%= link_to(t('users_list'), admin_users_url, 'data-no-turbolink' => true) %></li>
+              <% if can? :read, Organisation, id: current_user.organisation_id %>
+                <li><%= link_to(t('organisations_list'), admin_organisations_url, 'data-no-turbolink' => true) %></li>
+              <% end %>
+              <% if can? :read, User, organisation_id: current_user.organisation_id %>
+                <li><%= link_to(t('users_list'), admin_users_url, 'data-no-turbolink' => true) %></li>
+              <% end %>
               <li><%= link_to('Logout', destroy_user_session_path, :method => :delete) %></li>
             </ul>
           </div>

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Admin::OrganisationsController, type: :controller do
+  login_admin
+
   describe "GET index" do
     it "has a 200 status code" do
       get :index

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -1,59 +1,72 @@
 require "rails_helper"
 
 RSpec.describe Admin::OrganisationsController, type: :controller do
-  login_admin
+  describe "All permissions granted" do
+    login_admin
 
-  describe "GET index" do
-    it "has a 200 status code" do
-      get :index
-      expect(response.status).to eq(200)
+    describe "GET index" do
+      it "has a 200 status code" do
+        get :index
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET new" do
-    it "has a 200 status code" do
-      get :new
-      expect(response.status).to eq(200)
+    describe "GET new" do
+      it "has a 200 status code" do
+        get :new
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET edit" do
-    it "has a 200 status code" do
-      get :edit, id: FactoryGirl.create(:organisation).id
-      expect(response.status).to eq(200)
+    describe "GET edit" do
+      it "has a 200 status code" do
+        get :edit, id: FactoryGirl.create(:cites_ma).id
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET show" do
-    it "has a 200 status code" do
-      get :show, id: FactoryGirl.create(:organisation).id
-      expect(response.status).to eq(200)
+    describe "GET show" do
+      it "has a 200 status code" do
+        get :show, id: FactoryGirl.create(:cites_ma).id
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "POST create" do
-    it "creates a organisation" do
-      expect do
-        post :create, params: {
-          organisation: {
-            name: 'org_name',
-            role: 'CITES MA',
-            country_id: FactoryGirl.create(:country).id
+    describe "POST create" do
+      it "creates a organisation" do
+        expect do
+          post :create, params: {
+            organisation: {
+              name: 'org_name',
+              role: 'CITES MA',
+              country_id: FactoryGirl.create(:country).id
+            }
           }
-        }
-      end.to change{ Organisation.count }
+        end.to change{ Organisation.count }
 
-      expect(response.status).to eq(302)
+        expect(response.status).to eq(302)
+      end
+    end
+
+    describe "PATCH update" do
+      it "updates a organisation" do
+        organisation = FactoryGirl.create(:cites_ma)
+        patch :update, id: organisation.id, organisation: { name: 'asd'}
+        organisation.reload
+        expect(organisation.name).to eq('asd')
+        expect(response.status).to eq(302)
+      end
     end
   end
 
-  describe "PATCH update" do
-    it "updates a organisation" do
-      organisation = FactoryGirl.create(:organisation)
-      patch :update, id: organisation.id, organisation: { name: 'asd'}
-      organisation.reload
-      expect(organisation.name).to eq('asd')
-      expect(response.status).to eq(302)
+  describe "Restricted permissions" do
+    login_user
+
+    describe "GET index" do
+      it "should redirect" do
+        get :index
+        expect(response.status).to eq(302)
+      end
     end
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Admin::UsersController, type: :controller do
+  login_admin
+  let!(:same_org_user) {
+    FactoryGirl.create(:user,
+      organisation_id: @cites_ma.id
+    )
+  }
+
   describe "GET index" do
     it "has a 200 status code" do
       get :index
@@ -17,14 +24,14 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   describe "GET edit" do
     it "has a 200 status code" do
-      get :edit, id: FactoryGirl.create(:user).id
+      get :edit, id: same_org_user.id
       expect(response.status).to eq(200)
     end
   end
 
   describe "GET show" do
     it "has a 200 status code" do
-      get :show, id: FactoryGirl.create(:user).id
+      get :show, id: same_org_user.id
       expect(response.status).to eq(200)
     end
   end
@@ -49,19 +56,17 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   describe "PATCH update" do
     it "updates a user" do
-      user = FactoryGirl.create(:user)
-      patch :update, id: user.id, user: { first_name: 'asd'}
-      user.reload
-      expect(user.first_name).to eq('asd')
+      patch :update, id: same_org_user.id, user: { first_name: 'asd'}
+      same_org_user.reload
+      expect(same_org_user.first_name).to eq('asd')
       expect(response.status).to eq(302)
     end
   end
 
   describe "DELETE destroy" do
     it "destroys a user" do
-      user = FactoryGirl.create(:user)
       expect do
-        delete :destroy, id: user.id
+        delete :destroy, id: same_org_user.id
       end.to change{ User.count }
 
       expect(response.status).to eq(302)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Admin::UsersController, type: :controller do
-  create_organisations
   login_admin
+
   let!(:same_org_user) {
     FactoryGirl.create(:user,
       organisation_id: @cites_ma.id

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,76 +1,89 @@
 require "rails_helper"
 
 RSpec.describe Admin::UsersController, type: :controller do
-  login_admin
+  describe "All permissions granted" do
+    login_admin
 
-  let!(:same_org_user) {
-    FactoryGirl.create(:user,
-      organisation_id: @cites_ma.id
-    )
-  }
+    let!(:same_org_user) {
+      FactoryGirl.create(:user,
+        organisation_id: @cites_ma.id
+      )
+    }
 
-  describe "GET index" do
-    it "has a 200 status code" do
-      get :index
-      expect(response.status).to eq(200)
+    describe "GET index" do
+      it "has a 200 status code" do
+        get :index
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET new" do
-    it "has a 200 status code" do
-      get :new
-      expect(response.status).to eq(200)
+    describe "GET new" do
+      it "has a 200 status code" do
+        get :new
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET edit" do
-    it "has a 200 status code" do
-      get :edit, id: same_org_user.id
-      expect(response.status).to eq(200)
+    describe "GET edit" do
+      it "has a 200 status code" do
+        get :edit, id: same_org_user.id
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "GET show" do
-    it "has a 200 status code" do
-      get :show, id: same_org_user.id
-      expect(response.status).to eq(200)
+    describe "GET show" do
+      it "has a 200 status code" do
+        get :show, id: same_org_user.id
+        expect(response.status).to eq(200)
+      end
     end
-  end
 
-  describe "POST create" do
-    it "creates a user" do
-      expect do
-        post :create, params: {
-          user: {
-            first_name: 'name',
-            last_name: 'surname',
-            email: 'email@email.com',
-            password: 'asdasdasd',
-            password_confirmation: 'asdasdasd'
+    describe "POST create" do
+      it "creates a user" do
+        expect do
+          post :create, params: {
+            user: {
+              first_name: 'name',
+              last_name: 'surname',
+              email: 'email@email.com',
+              password: 'asdasdasd',
+              password_confirmation: 'asdasdasd'
+            }
           }
-        }
-      end.to change{ User.count }
+        end.to change{ User.count }
 
-      expect(response.status).to eq(302)
+        expect(response.status).to eq(302)
+      end
+    end
+
+    describe "PATCH update" do
+      it "updates a user" do
+        patch :update, id: same_org_user.id, user: { first_name: 'asd'}
+        same_org_user.reload
+        expect(same_org_user.first_name).to eq('asd')
+        expect(response.status).to eq(302)
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "destroys a user" do
+        expect do
+          delete :destroy, id: same_org_user.id
+        end.to change{ User.count }
+
+        expect(response.status).to eq(302)
+      end
     end
   end
 
-  describe "PATCH update" do
-    it "updates a user" do
-      patch :update, id: same_org_user.id, user: { first_name: 'asd'}
-      same_org_user.reload
-      expect(same_org_user.first_name).to eq('asd')
-      expect(response.status).to eq(302)
-    end
-  end
+  describe "Restricted permissions" do
+    login_user
 
-  describe "DELETE destroy" do
-    it "destroys a user" do
-      expect do
-        delete :destroy, id: same_org_user.id
-      end.to change{ User.count }
-
-      expect(response.status).to eq(302)
+    describe "GET index" do
+      it "should redirect" do
+        get :index
+        expect(response.status).to eq(302)
+      end
     end
   end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Admin::UsersController, type: :controller do
+  create_organisations
   login_admin
   let!(:same_org_user) {
     FactoryGirl.create(:user,

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -80,9 +80,12 @@ RSpec.describe Admin::UsersController, type: :controller do
     login_user
 
     describe "GET index" do
-      it "should redirect" do
+      it "should filter list by same organisation" do
+        same_org_id = subject.current_user.organisation_id
+        FactoryGirl.create(:user, organisation_id: same_org_id)
         get :index
-        expect(response.status).to eq(302)
+        expect(assigns(:users).size).to eq(2)
+        expect(response.status).to eq(200)
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
+  create_organisations
   login_user
 
   it "should have a current_user" do

--- a/spec/factories/adapter.rb
+++ b/spec/factories/adapter.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :adapter do
-    name { Faker::Superhero.name }
+    sequence(:name) { |n| "#{n}#{Faker::Superhero.name}" }
     web_service_type 'SOAP'
     web_service_uri { Faker::Internet.url }
     is_available true

--- a/spec/factories/adapter.rb
+++ b/spec/factories/adapter.rb
@@ -1,10 +1,8 @@
 FactoryGirl.define do
   factory :adapter do
-    country
-    name Faker::Superhero.name
+    name { Faker::Superhero.name }
     web_service_type 'SOAP'
-    web_service_uri Faker::Internet.url
+    web_service_uri { Faker::Internet.url }
     is_available true
-    organisation
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :organisation do
-    name Faker::Company.name
-    role 'CITES MA'
+    name { Faker::Company.name }
+    role Organisation::CITES_MA
     country
+    adapter
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :organisation do
     sequence(:name) { |n| "#{n}#{Faker::Company.name}" }
+    role Organisation::SYSTEM_MANAGERS
     country
     adapter
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,8 +1,14 @@
 FactoryGirl.define do
   factory :organisation do
-    name { Faker::Company.name }
-    role Organisation::CITES_MA
+    sequence(:name) { |n| "#{n}#{Faker::Company.name}" }
     country
     adapter
+
+    Organisation::VALID_ROLES.each do |role|
+      role_name = role.downcase.tr(" ", "_")
+      factory :"#{role_name}" do
+        role role
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,12 +5,12 @@ FactoryGirl.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     is_admin false
-    organisation FactoryGirl.create(:cites_ma)
+    organisation { FactoryGirl.create(:cites_ma) }
 
     Organisation::VALID_ROLES.each do |role|
       role_name = role.downcase.tr(" ", "_")
       factory :"#{role_name}_user" do
-        organisation FactoryGirl.create(role_name.to_sym)
+        organisation { FactoryGirl.create(role_name.to_sym) }
         is_admin true
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,15 @@ FactoryGirl.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     is_admin false
-    organisation
+    organisation FactoryGirl.create(:cites_ma)
+
+    Organisation::VALID_ROLES.each do |role|
+      role_name = role.downcase.tr(" ", "_")
+      factory :"#{role_name}_user" do
+        organisation FactoryGirl.create(role_name.to_sym)
+        is_admin true
+      end
+    end
   end
 end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,11 @@
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "#{n}#{Faker::Internet.email}" }
-    password Faker::Internet.password(10, 20)
-    first_name Faker::Name.first_name
-    last_name Faker::Name.last_name
+    password { Faker::Internet.password(10, 20) }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     is_admin false
+    organisation
   end
 end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Organisation, type: :model do
   }
 
   it "has a valid role" do
-    expect(FactoryGirl.build(:organisation)).to be_valid
+    expect(FactoryGirl.build(:cites_ma)).to be_valid
   end
 
   it "has an invalid role" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,14 +40,12 @@ RSpec.describe User, type: :model do
       it { is_expected.to be_able_to(:update, Organisation, id: user.organisation.id) }
       it { is_expected.to be_able_to(:update, Adapter, id: user.organisation.adapter.id) }
       it { is_expected.to be_able_to(:manage, User, organisation_id: user.organisation_id) }
-      it { is_expected.not_to be_able_to(:index, User) }
     end
 
     context "when is customs ea" do
       let(:user){ FactoryGirl.create(:customs_ea_user) }
       it { is_expected.to be_able_to(:update, Organisation, id: user.organisation.id) }
       it { is_expected.to be_able_to(:manage, User, organisation_id: user.organisation_id) }
-      it { is_expected.not_to be_able_to(:index, User) }
     end
 
     context "when is other" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,12 +40,14 @@ RSpec.describe User, type: :model do
       it { is_expected.to be_able_to(:update, Organisation, id: user.organisation.id) }
       it { is_expected.to be_able_to(:update, Adapter, id: user.organisation.adapter.id) }
       it { is_expected.to be_able_to(:manage, User, organisation_id: user.organisation_id) }
+      it { is_expected.not_to be_able_to(:index, User) }
     end
 
     context "when is customs ea" do
       let(:user){ FactoryGirl.create(:customs_ea_user) }
       it { is_expected.to be_able_to(:update, Organisation, id: user.organisation.id) }
       it { is_expected.to be_able_to(:manage, User, organisation_id: user.organisation_id) }
+      it { is_expected.not_to be_able_to(:index, User) }
     end
 
     context "when is other" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe User, type: :model do
     expect(FactoryGirl.build(:user, email: nil)).to be_invalid
   end
 
-  subject { FactoryGirl.create(:user) }
+  subject { FactoryGirl.create(:cites_ma_user) }
 
   it 'sends an email' do
     expect { subject.send_welcome_email }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,16 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,6 +1,5 @@
 module ControllerMacros
   def login_user
-    create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryGirl.create(:user, organisation_id: @cites_ma.id)
@@ -9,7 +8,6 @@ module ControllerMacros
   end
 
   def login_admin
-    create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryGirl.create(:user,
@@ -24,7 +22,7 @@ module ControllerMacros
     before(:each) do
       Organisation::VALID_ROLES.each do |role|
         role_name = role.downcase.tr(" ", "_")
-        organisation = FactoryGirl.create(:organisation, role: role)
+        organisation = FactoryGirl.create(role_name.to_sym)
         instance_variable_set("@#{role_name}", organisation)
       end
     end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,5 +1,6 @@
 module ControllerMacros
   def login_user
+    create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryGirl.create(:user, organisation_id: @cites_ma.id)
@@ -8,11 +9,12 @@ module ControllerMacros
   end
 
   def login_admin
+    create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryGirl.create(:user,
         is_admin: true,
-        organisation_id: @cites_ma.id
+        organisation_id: @system_managers.id
       )
       sign_in user
     end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -3,7 +3,7 @@ module ControllerMacros
     create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = FactoryGirl.create(:user, organisation_id: @other.id)
+      user = FactoryGirl.create(:cites_ma_user)
       sign_in user
     end
   end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,9 +1,32 @@
 module ControllerMacros
   def login_user
+    create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = FactoryGirl.create(:user)
+      user = FactoryGirl.create(:user, organisation_id: @cites_ma.id)
       sign_in user
+    end
+  end
+
+  def login_admin
+    create_organisations
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      user = FactoryGirl.create(:user,
+        is_admin: true,
+        organisation_id: @cites_ma.id
+      )
+      sign_in user
+    end
+  end
+
+  def create_organisations
+    before(:each) do
+      Organisation::VALID_ROLES.each do |role|
+        role_name = role.downcase.tr(" ", "_")
+        organisation = FactoryGirl.create(:organisation, role: role)
+        instance_variable_set("@#{role_name}", organisation)
+      end
     end
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -3,7 +3,7 @@ module ControllerMacros
     create_organisations
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = FactoryGirl.create(:user, organisation_id: @cites_ma.id)
+      user = FactoryGirl.create(:user, organisation_id: @other.id)
       sign_in user
     end
   end


### PR DESCRIPTION
[Accomodates roles and permissions for organisations and users](https://www.pivotaltracker.com/story/show/121745645).
All the abilities for the user are specified using cancan in the `ability` class. Authorisations are then granted and checked in the organisations and users controllers.
I also denied access to the lists of organisations and users for non-managers; I think we will have a different page where to handle single organisation etc.

The only issue I can't figure out how to solve is about the flash messages that sometimes don't show after redirecting due to `CanCan::AccessDenied`.
Granting access to the index pages for users for examples, and then from that page moving to the denied lists of organisations, the flash message is not displayed, and the reason is because the home page is `rendered twice`.
The issue seems to be fired by `turbolinks`, specifically with `chrome`.
Removing turbolinks from `admin.js` fixes the issue though. 
