### PR TITLE
Fetch permit details

### DIFF
--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -1,6 +1,9 @@
 class PermitsController < ApplicationController
   def index
-    @countries = Country.select(:id, :name)
+    @countries = Organisation.cites_mas.with_available_adapters.
+      joins(:country).
+      select('countries.iso_code2, countries.name').
+      group('countries.iso_code2, countries.name')
   end
 
   def show

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -1,5 +1,13 @@
 class PermitsController < ApplicationController
+  before_action :sanitise_params, only: [:index, :show]
+  before_action :load_adapter, only: [:show]
+
   def index
+    if @country && @permit_identifier
+      redirect_to(permit_path(
+        country: @country, permit_identifier: @permit_identifier
+      )) && return
+    end
     @countries = Organisation.cites_mas.with_available_adapters.
       joins(:country).
       select('countries.iso_code2, countries.name').
@@ -7,5 +15,32 @@ class PermitsController < ApplicationController
   end
 
   def show
+    @response = Adapters::SimpleAdapter.run(
+      @adapter, {
+        certificate_number: @permit_identifier,
+        token_id: '?',
+        country: @country
+      }
+    )
   end
+
+  private
+
+  def sanitise_params
+    @country = params[:country] && params[:country].strip[0..1]
+    @permit_identifier = params[:permit_identifier]
+  end
+
+  def load_adapter
+    organisation = Organisation.cites_mas.with_available_adapters.
+      joins(:country).where('countries.iso_code2' => params[:country]).
+      first
+    unless organisation.present?
+      flash.alert = 'Adapter not found or not available'
+      redirect_to(permits_path) && return
+    end
+    @adapter = organisation.adapter
+  end
+
+
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -13,6 +13,13 @@ class Organisation < ApplicationRecord
   validates :role, uniqueness: {scope: :country}
   validates_inclusion_of :role, in: VALID_ROLES
 
+  scope :cites_mas, -> {
+    where(role: CITES_MA)
+  }
+  scope :with_available_adapters, -> {
+    joins(:adapter).where('adapters.is_available' => true)
+  }
+
   def display_name
     if [CITES_MA, CUSTOMS_EA].include?(role) && country.present?
       [role, 'of', country.name].join(' ')

--- a/app/views/permits/index.html.erb
+++ b/app/views/permits/index.html.erb
@@ -6,7 +6,7 @@
       <%= label_tag(:country, t('select_country')) %>
       <%= select_tag(
         :country,
-        options_for_select(@countries.map { |c| [c.name, c.id] }),
+        options_for_select(@countries.map { |c| [c.name, c.iso_code2] }),
         class: 'form-control'
       ) %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Rails.application.routes.draw do
   }
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
+  get 'permits/:country/:permit_identifier' => 'permits#show',
+    as: 'permit',
+    constraint: { country: /\w\w/ }
   resources :permits, only: [:index]
-  get 'permits/show' => 'permits#show'
 
   namespace :admin do
     resources :organisations, except: [:destroy]

--- a/db/migrate/20160829120425_remove_country_id_from_adapters.rb
+++ b/db/migrate/20160829120425_remove_country_id_from_adapters.rb
@@ -1,0 +1,9 @@
+class RemoveCountryIdFromAdapters < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :adapters, :country_id
+  end
+
+  def down
+    add_reference :adapters, :country, index: true, foreign_key: true
+  end
+end

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -1,30 +1,29 @@
 class Adapters::Base
   attr_reader :params
 
-  def self.run(adapter)
+  def self.run(adapter, message = {})
     instance = self.new(adapter)
-    instance.request
+    instance.request(message)
   end
 
   def initialize(adapter)
     @params = {}
   end
 
-  def request
-    send(@params[:request_type])
+  def request(message = {})
+    send(@params[:request_type], message)
   end
 
   private
 
-  def soap_request
+  def soap_request(message = {})
     wsdl = @params[:wsdl]
     operation = @params[:operation]
     auth = @params[:auth]
-    options = @params[:options]
     timeout = @params[:timeout]
     begin
       Timeout::timeout(timeout) {
-       Transports::Soap.request(wsdl, operation, auth, options)
+       Transports::Soap.request(wsdl, operation, auth, message)
       }
     rescue => e
       if e.is_a?(Timeout::Error)
@@ -35,7 +34,7 @@ class Adapters::Base
     end
   end
 
-  def rest_request
+  def rest_request(message = {})
   end
 
 end

--- a/lib/modules/adapters/simple_adapter.rb
+++ b/lib/modules/adapters/simple_adapter.rb
@@ -2,8 +2,7 @@ class Adapters::SimpleAdapter < Adapters::Base
 
   #Example on how to invoke the adapter
   #
-  #  selected_country = 'Simple'
-  #  adapter = Country.find_by_name(selected_country).adapter
+  #  adapter = Organisation.find(organisation_id).adapter
   #  if adapter.is_available
   #    @res = adapter.name.constantize.run(adapter)
   #  else
@@ -15,7 +14,6 @@ class Adapters::SimpleAdapter < Adapters::Base
       wsdl: adapter.web_service_uri,
       timeout: adapter.time_out,
       operation: :get_non_final_cites_certificate,
-      options: {},
       auth: {
         username: '',
         password: ''


### PR DESCRIPTION
This does not populate the permit details page as I'm not yet done with that, but I thought it might be useful to merge this bit, as it makes the search button "work" by routing to the permit details page and actually fetching the permit from the web service, passing the requested parameters. For this to work the dummy WS adapter needs to be defined. The list of countries in the search drop down is also filtered down to those countries who have CITES MA organisations with available adapters, so to prepare data you need the appropriate adapter, organisation and country.
