### PR TITLE
Populate permit details

### DIFF
--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -22,6 +22,7 @@ class PermitsController < ApplicationController
         country: @country
       }
     )
+    @permit = Permit.new(@response.body[:get_non_final_cites_certificate_response])
   end
 
   private

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -22,7 +22,9 @@ class PermitsController < ApplicationController
         country: @country
       }
     )
-    @permit = Permit.new(@response.body[:get_non_final_cites_certificate_response])
+
+    xml = Nokogiri::XML(@response.to_xml)
+    @permit = Permit.new(xml)
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def date_format(datetime_string)
+    begin
+      Date.parse(datetime_string).strftime("%d-%m-%Y")
+    rescue ArgumentError
+      ''
+    end
+  end
 end

--- a/app/views/permits/_conditions_and_management.html.erb
+++ b/app/views/permits/_conditions_and_management.html.erb
@@ -4,20 +4,23 @@
       <div class="permit-field field-title">
         5. <%= t('special_conditions') %>
       </div>
-      <div class="permit-value"><%= "Placeholder" %></div>
+      <div class="permit-value"><%= @permit.special_conditions %></div>
     </div>
     <div class="row permit-row height-30 no-padding">
       <div class="col col-xs-6 col-md-6 col-lg-6 permit-col hor-padded-15">
         <div class="permit-field field-title">
           5a. <%= t('purpose_of_transaction').html_safe %>
         </div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value">
+          <%= @permit.purpose_code %>
+          <%= @permit.purpose %>
+        </div>
       </div>
       <div class="col col-xs-6 col-md-6 col-lg-6 permit-col border-lft padded-15">
         <div class="permit-field field-title">
           5b. <%= t('security_stamp_no') %>
         </div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value"><%= @permit.security_stamp_no %></div>
       </div>
     </div>
   </div>
@@ -28,7 +31,12 @@
           6. <%= t('management_authority').html_safe %>
         </span>
       </div>
-      <div class="permit-value"><%= "Placeholder" %></div>
+      <div class="permit-value">
+        <p><%= @permit.issuing_authority_name %></p>
+        <p><%= @permit.issuing_authority_postal_address %></p>
+        <p><%= @permit.issuing_authority_country %></p>
+        <p><%= @permit.issuing_authority_representative_person %></p>
+      </div>
     </div>
   </div>
 </div> <!-- Conditions and management row -->

--- a/app/views/permits/_endorsement_and_bill.html.erb
+++ b/app/views/permits/_endorsement_and_bill.html.erb
@@ -12,26 +12,15 @@
           </tr>
         </thead>
         <tbody>
-          <%# for each species (see species table) do %>
+          <% @permit.line_items.each do |line_item| %>
             <tr>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-              <td class="endorsement-quantity"><%= "Placeholder" %></td>
+              <td class="endorsement-block"><%= line_item.id %></td>
+              <td class="endorsement-quantity">
+                <%= line_item.final_quantity %>
+                <%= line_item.final_unit_code %>
+              </td>
             </tr>
-          <%# end %>
-          <!-- just as an example -->
-            <tr>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-            </tr>
-            <tr>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-            </tr>
-            <tr>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-              <td class="endorsement-block"><%= "Placeholder" %></td>
-            </tr>
-          <!-- just as an example -->
+          <% end %>
         </tbody>
       </table>
     </div>

--- a/app/views/permits/_endorsement_and_bill.html.erb
+++ b/app/views/permits/_endorsement_and_bill.html.erb
@@ -39,16 +39,16 @@
       <div class="permit-field field-title inline">
         15. <%= t('bill') %>
       </div>
-      <div class="permit-value inline"><%= "Placeholder" %></div>
+      <div class="permit-value inline"><%= @permit.transport_document %></div>
       <div class="vertical-fields">
         <div class="vertical-fields-first inline">
-          <div class="permit-value border-btm"><%= "Placeholder" %></div>
+          <div class="permit-value border-btm"><%= @permit.port_of_export %></div>
           <div class="permit-field field-title">
             <%= t('port') %>
           </div>
         </div>
         <div class="vertical-fields-second inline">
-          <div class="permit-value border-btm"><%= "Placeholder" %></div>
+          <div class="permit-value border-btm"><%= @permit.date_of_export %></div>
           <div class="permit-field field-title">
             <%= t('date') %>
           </div>

--- a/app/views/permits/_import_export.html.erb
+++ b/app/views/permits/_import_export.html.erb
@@ -6,13 +6,16 @@
           3. <%= t('importer').html_safe %>
         </span>
       </div>
-      <div class="permit-value"><%= "Placeholder" %></div>
+      <div class="permit-value">
+        <p><%= @permit.consignee_name %></p>
+        <p><%= @permit.consignee_postal_address %></p>
+      </div>
     </div>
     <div class="row permit-row height-30">
       <div class="permit-field field-title inline">
         3a. <%= t('country_of_import') %>
       </div>
-      <div class="permit-value inline"><%= "Placeholder" %></div>
+      <div class="permit-value inline"><%= @permit.consignee_country %></div>
     </div>
   </div>
   <div class="col col-xs-6 col-md-6 col-lg-6 permit-col border-lft">
@@ -22,7 +25,11 @@
           4. <%= t('exporter').html_safe %>
         </span>
       </div>
-      <div class="permit-value"><%= "Placeholder" %></div>
+      <div class="permit-value">
+        <p><%= @permit.consignor_name %></p>
+        <p><%= @permit.consignor_postal_address %></p>
+        <p><%= @permit.consignor_country %></p>
+      </div>
     </div>
   </div>
 </div> <!-- Import-export row -->

--- a/app/views/permits/_issued_by.html.erb
+++ b/app/views/permits/_issued_by.html.erb
@@ -5,13 +5,13 @@
   <div class="permit-value inline"><%= "Placeholder" %></div>
   <div class="vertical-fields">
     <div class="vertical-fields-first inline">
-      <div class="permit-value border-btm"><%= "Placeholder" %></div>
+      <div class="permit-value border-btm"><%= @permit.issue_place %></div>
       <div class="permit-field field-title">
         <%= t('place') %>
       </div>
     </div>
     <div class="vertical-fields-second inline">
-      <div class="permit-value border-btm"><%= "Placeholder" %></div>
+      <div class="permit-value border-btm"><%= @permit.issue_date_time %></div>
       <div class="permit-field field-title">
         <%= t('date') %>
       </div>

--- a/app/views/permits/_issued_by.html.erb
+++ b/app/views/permits/_issued_by.html.erb
@@ -2,7 +2,7 @@
   <div class="permit-field field-title inline">
     13. <%= t('issued_by') %>
   </div>
-  <div class="permit-value inline"><%= "Placeholder" %></div>
+  <div class="permit-value inline"><%= @permit.issued_by %></div>
   <div class="vertical-fields">
     <div class="vertical-fields-first inline">
       <div class="permit-value border-btm"><%= @permit.issue_place %></div>
@@ -11,7 +11,7 @@
       </div>
     </div>
     <div class="vertical-fields-second inline">
-      <div class="permit-value border-btm"><%= @permit.issue_date_time %></div>
+      <div class="permit-value border-btm"><%= date_format(@permit.issue_date) %></div>
       <div class="permit-field field-title">
         <%= t('date') %>
       </div>

--- a/app/views/permits/_permit_type.html.erb
+++ b/app/views/permits/_permit_type.html.erb
@@ -37,7 +37,7 @@
           <div class="permit-field field-title">
             2. <%= t('valid_until') %>
           </div>
-          <div class="permit-value"><%= @permit.valid_until %></div>
+          <div class="permit-value"><%= date_format(@permit.valid_until) %></div>
         </div>
       </div>
     </div>

--- a/app/views/permits/_permit_type.html.erb
+++ b/app/views/permits/_permit_type.html.erb
@@ -5,22 +5,22 @@
       <div class="col-col-sm-6 col-md-6 col-lg-6 permit-col">
         <ul>
           <li>
-            <%= check_box_tag "export", "export", true, { class: 'permit-check', disabled: true } %>
+            <%= check_box_tag "export", "export", @permit.type_code == 'E', { class: 'permit-check', disabled: true } %>
             <span></span>
             <%= label_tag :export, t("export").mb_chars.upcase %>
           </li>
           <li>
-            <%= check_box_tag "re-export", "re-export", false, { class: 'permit-check', disabled: true } %>
+            <%= check_box_tag "re-export", "re-export", @permit.type_code == 'R', { class: 'permit-check', disabled: true } %>
             <span></span>
             <%= label_tag :export, t("re_export").mb_chars.upcase %>
           </li>
           <li>
-            <%= check_box_tag "import", "import", false, { class: 'permit-check', disabled: true } %>
+            <%= check_box_tag "import", "import", @permit.type_code == 'I', { class: 'permit-check', disabled: true } %>
             <span></span>
             <%= label_tag :export, t("import").mb_chars.upcase %>
           </li>
           <li>
-            <%= check_box_tag "other", "other", false, { class: 'permit-check', disabled: true } %>
+            <%= check_box_tag "other", "other", @permit.type_code == 'O', { class: 'permit-check', disabled: true } %>
             <span></span>
             <%= label_tag :export, "#{t("other").mb_chars.upcase}:" %>
           </li>
@@ -31,13 +31,13 @@
           <div class="permit-field field-title">
             <%= t('permit_certificate') %>
           </div>
-          <div class="permit-value"><%= "Placeholder" %></div>
+          <div class="permit-value"><%= @permit.identifier %></div>
         </div>
         <div class="row permit-row height-50 border-no-btm padded-15">
           <div class="permit-field field-title">
             2. <%= t('valid_until') %>
           </div>
-          <div class="permit-value"><%= "Placeholder" %></div>
+          <div class="permit-value"><%= @permit.valid_until %></div>
         </div>
       </div>
     </div>

--- a/app/views/permits/_species_details_block.html.erb
+++ b/app/views/permits/_species_details_block.html.erb
@@ -1,6 +1,6 @@
 <div class="species-details-block row row-container">
   <div class="col permit-col index-col">
-    <div class="index-value bold">A</div>
+    <div class="index-value bold"><%= line_item.id %></div>
   </div>
   <div class="col block-col permit-col">
     <div class="row species-details-row height-53">
@@ -8,25 +8,42 @@
         <div class="row row-container permit-row hor-padded-15">
           <div class="col col-48">
             <div class="permit-field field-title">7./8.</div>
-            <div class="permit-value"><%= "Placeholder" %></div>
+            <div class="permit-value">
+              <%= line_item.scientific_name %>
+              <%= line_item.common_name %>
+            </div>
           </div>
           <div class="col col-48">
             <div class="permit-field field-title">9.</div>
-            <div class="permit-value"><%= "Placeholder" %></div>
+            <div class="permit-value">
+              <%= line_item.term %>
+              <%= line_item.term_code %>
+            </div>
           </div>
         </div>
       </div>
       <div class="col species-col-small permit-col border-lft padded-15 border-btm">
         <div class="permit-field field-title">10.</div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value">
+          <%= line_item.appendix %>
+          <%= line_item.source %>
+        </div>
       </div>
       <div class="col species-col-small permit-col border-lft padded-15 border-btm">
         <div class="permit-field field-title">11.</div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value">
+          <%= line_item.quantity %>
+          <%= line_item.unit_code %>
+        </div>
       </div>
       <div class="col species-col-small permit-col border-lft padded-15 border-btm">
         <div class="permit-field field-title">11a.</div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value">
+          <%= line_item.used_to_date_quantity %>
+          <%= line_item.used_to_date_unit_code %> /
+          <%= line_item.annual_quota_quantity %>
+          <%= line_item.annual_quota_unit_code %>
+        </div>
       </div>
     </div>
     <div class="row other-details-row height-47">
@@ -36,19 +53,19 @@
             <div class="permit-field field-title">
               12. <%= t('country_of_origin') %>
             </div>
-            <div class="permit-value"><%= "Placeholder" %></div>
+            <div class="permit-value"><%= line_item.origin_country %></div>
           </div>
           <div class="col col-xs-4 col-md-4 col-lg-4 permit-no">
             <div class="permit-field field-title">
               <%= t('permit_no') %>
             </div>
-            <div class="permit-value border-lft"><%= "Placeholder" %></div>
+            <div class="permit-value border-lft"><%= line_item.origin_permit_id %></div>
           </div>
           <div class="col col-xs-3 col-md-3 col-lg-3 date">
             <div class="permit-field field-title">
               <%= t('date') %>
             </div>
-            <div class="permit-value border-lft"><%= "Placeholder" %></div>
+            <div class="permit-value border-lft"><%= date_format(line_item.origin_permit_date) %></div>
           </div>
         </div>
       </div>
@@ -58,19 +75,19 @@
             <div class="permit-field field-title">
               12a. <%= t('last_country') %>
             </div>
-            <div class="permit-value"><%= "Placeholder" %></div>
+            <div class="permit-value"><%= line_item.export_country %></div>
           </div>
           <div class="col col-xs-3 col-md-3 col-lg-3 certificate-no">
             <div class="permit-field field-title">
               <%= t('certificate_no') %>
             </div>
-            <div class="permit-value border-lft"><%= "Placeholder" %></div>
+            <div class="permit-value border-lft"><%= line_item.export_permit_id %></div>
           </div>
           <div class="col col-xs-3 col-md-3 col-lg-3 date">
             <div class="permit-field field-title">
               <%= t('date') %>
             </div>
-            <div class="permit-value border-lft"><%= "Placeholder" %></div>
+            <div class="permit-value border-lft"><%= date_format(line_item.export_permit_date) %></div>
           </div>
         </div>
       </div>
@@ -78,7 +95,9 @@
         <div class="permit-field field-title">
           12b. <%= t('operation_no') %>
         </div>
-        <div class="permit-value"><%= "Placeholder" %></div>
+        <div class="permit-value">
+          <%= date_format(line_item.operation_no) %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/permits/_species_details_table.html.erb
+++ b/app/views/permits/_species_details_table.html.erb
@@ -1,10 +1,7 @@
 <div class="species-details-table">
-  <%# for each species_details do |species_detial| %>
-    <%= render "species_details_block" %>
-    <%= render "species_details_block" %>
-    <%= render "species_details_block" %>
-    <%= render "species_details_block" %>
-  <%# end %>
+  <% @permit.line_items.each do |line_item| %>
+    <%= render "species_details_block", line_item: line_item %>
+  <% end %>
 </div>
 <div class="country-info border-btm">
 <%= t('country_info') %>

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -23,7 +23,7 @@ class Adapters::Base
     timeout = @params[:timeout]
     begin
       Timeout::timeout(timeout) {
-       Transports::Soap.request(wsdl, operation, auth, message)
+        Transports::Soap.request(wsdl, operation, auth, message)
       }
     rescue => e
       if e.is_a?(Timeout::Error)

--- a/lib/modules/permit.rb
+++ b/lib/modules/permit.rb
@@ -1,0 +1,197 @@
+class Permit
+
+  # Initialise using body of permit response converted to a hash
+  def initialize(body)
+    @body = body
+  end
+
+  # Box 1
+
+  # always present
+  def identifier
+    header_exchanged_document[:id]
+  end
+
+  # TODO: where does this go?
+  def name
+    header_exchanged_document[:name]
+  end
+
+  # always present
+  def type_code
+    header_exchanged_document[:type_code]
+  end
+
+  # TODO: where does this go?
+  def copy_indicator
+    header_exchanged_document[:copy_indicator]
+  end
+
+  # Box 2
+
+  # TODO: where does this go?
+  def valid_from
+    header_exchanged_document[:effective_specified_period][:start_date_time]
+  end
+
+  def valid_until
+    header_exchanged_document[:effective_specified_period][:end_date_time]
+  end
+
+  # Box 3
+
+  # TODO: where does this go?
+  def consignee_id
+    trade_party_id(
+      specified_supply_chain_consignment[:consignee_trade_party]
+    )
+  end
+
+  def consignee_name
+    trade_party_name(
+      specified_supply_chain_consignment[:consignee_trade_party]
+    )
+  end
+
+  def consignee_postal_address
+    trade_party_postal_address(
+      specified_supply_chain_consignment[:consignee_trade_party]
+    )
+  end
+
+  # Box 3a
+
+  def consignee_country
+    trade_party_country(
+      specified_supply_chain_consignment[:consignee_trade_party]
+    )
+  end
+
+  # Box 4
+
+  # TODO: where does this go?
+  def consignor_id
+    trade_party_id(
+      specified_supply_chain_consignment[:consignor_trade_party]
+    )
+  end
+
+  def consignor_name
+    trade_party_name(
+      specified_supply_chain_consignment[:consignor_trade_party]
+    )
+  end
+
+  def consignor_postal_address
+    trade_party_postal_address(
+      specified_supply_chain_consignment[:consignor_trade_party]
+    )
+  end
+
+  def consignor_country
+    trade_party_country(
+      specified_supply_chain_consignment[:consignor_trade_party]
+    )
+  end
+
+  # Box 5a
+
+  def purpose
+    header_exchanged_document[:purpose]
+  end
+
+  # always present
+  def purpose_code
+    header_exchanged_document[:purpose_code]
+  end
+
+  # Box 5
+
+  def special_conditions
+    header_exchanged_document[:information]
+  end
+
+  # Box 5b
+
+  def security_stamp_no
+    first_signatory_document_authentication[:id]
+  end
+
+  # Box 6
+
+  # TODO: where does this go?
+  def issuing_authority_id
+    trade_party_id(
+      first_signatory_document_authentication[:provider_trade_party]
+    )
+  end
+
+  def issuing_authority_name
+    trade_party_name(
+      first_signatory_document_authentication[:provider_trade_party]
+    )
+  end
+
+  def issuing_authority_postal_address
+    trade_party_postal_address(
+      first_signatory_document_authentication[:provider_trade_party]
+    )
+  end
+
+  def issuing_authority_country
+    trade_party_country(
+      first_signatory_document_authentication[:provider_trade_party]
+    )
+  end
+
+  def issuing_authority_representative_person
+    first_signatory_document_authentication[:provider_trade_party][:specified_representative_person][:name]
+  end
+
+  # Box 13
+
+  def issue_place
+    header_exchanged_document[:issue_logistics_location][:name]
+  end
+
+  # always present
+  def issue_date_time
+    header_exchanged_document[:issue_date_time]
+  end
+
+  private
+
+  def header_exchanged_document
+    @body[:cbf_ship][:header_exchanged_document]
+  end
+
+  def specified_supply_chain_consignment
+    @body[:cbf_ship][:specified_supply_chain_consignment]
+  end
+
+  def first_signatory_document_authentication
+    header_exchanged_document[:first_signatory_document_authentication]
+  end
+
+  def trade_party_id(node)
+    node[:id]
+  end
+
+  def trade_party_name(node)
+    node[:name]
+  end
+
+  def trade_party_postal_address(node)
+    [:street_name, :post_office_box, :city_name, :postcode_code].map do |address_part|
+      node[:postal_trade_address][address_part]
+    end.compact.join(', ')
+  end
+
+  def trade_party_country(node)
+    parts = [:id, :name].map do |country_name_part|
+      node[:postal_trade_address][:country_identification_trade_country][country_name_part]
+    end
+    parts << node[:postal_trade_address][:country_identification_trade_country][:subordinate_trade_country_sub_division][:name]
+    parts.compact.join(', ')
+  end
+end

--- a/lib/modules/permit.rb
+++ b/lib/modules/permit.rb
@@ -5,6 +5,12 @@ class Permit
     @body = body
   end
 
+  def line_items
+    specified_supply_chain_consignment.xpath('urn1:IncludedSupplyChainConsignmentItem').map do |xml|
+      PermitLineItem.new(xml)
+    end
+  end
+
   # Box 1
 
   # always present

--- a/lib/modules/permit.rb
+++ b/lib/modules/permit.rb
@@ -1,6 +1,6 @@
 class Permit
 
-  # Initialise using body of permit response converted to a hash
+  # Initialise using XML body of permit response
   def initialize(body)
     @body = body
   end
@@ -150,13 +150,35 @@ class Permit
 
   # Box 13
 
+  def issued_by
+    trade_party_name(
+      third_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty')
+    )
+  end
+
   def issue_place
     header_exchanged_document.at_xpath('urn1:IssueLogisticsLocation/urn1:Name').content
   end
 
   # always present
-  def issue_date_time
+  def issue_date
     header_exchanged_document.at_xpath('urn1:IssueDateTime').content
+  end
+
+  # Box 14
+
+  def date_of_export
+    specified_supply_chain_consignment.at_xpath('urn1:ExaminationTransportEvent/urn1:ActualOccurrenceDateTime').content
+  end
+
+  def port_of_export
+    specified_supply_chain_consignment.at_xpath('urn1:ExaminationTransportEvent/urn1:OccurrenceLogisticsLocation/urn1:ID').content
+  end
+
+  # Box 15
+
+  def transport_document
+    specified_supply_chain_consignment.at_xpath('urn1:TransportContractReferencedDocument/urn1:ID').content
   end
 
   private
@@ -171,6 +193,10 @@ class Permit
 
   def first_signatory_document_authentication
     header_exchanged_document.at_xpath('urn1:FirstSignatoryDocumentAuthentication')
+  end
+
+  def third_signatory_document_authentication
+    header_exchanged_document.at_xpath('urn1:ThirdSignatoryDocumentAuthentication')
   end
 
   def trade_party_id(node)

--- a/lib/modules/permit.rb
+++ b/lib/modules/permit.rb
@@ -9,33 +9,33 @@ class Permit
 
   # always present
   def identifier
-    header_exchanged_document[:id]
+    header_exchanged_document.at_xpath('urn1:ID').content
   end
 
   # TODO: where does this go?
   def name
-    header_exchanged_document[:name]
+    header_exchanged_document.at_xpath('urn1:Name').content
   end
 
   # always present
   def type_code
-    header_exchanged_document[:type_code]
+    header_exchanged_document.at_xpath('urn1:TypeCode').content
   end
 
   # TODO: where does this go?
   def copy_indicator
-    header_exchanged_document[:copy_indicator]
+    header_exchanged_document.at_xpath('urn1:CopyIndicator').content
   end
 
   # Box 2
 
   # TODO: where does this go?
   def valid_from
-    header_exchanged_document[:effective_specified_period][:start_date_time]
+    header_exchanged_document.at_xpath('urn1:EffectiveSpecifiedPeriod/urn1:StartDateTime').content
   end
 
   def valid_until
-    header_exchanged_document[:effective_specified_period][:end_date_time]
+    header_exchanged_document.at_xpath('urn1:EffectiveSpecifiedPeriod/urn1:EndDateTime').content
   end
 
   # Box 3
@@ -43,19 +43,19 @@ class Permit
   # TODO: where does this go?
   def consignee_id
     trade_party_id(
-      specified_supply_chain_consignment[:consignee_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsigneeTradeParty')
     )
   end
 
   def consignee_name
     trade_party_name(
-      specified_supply_chain_consignment[:consignee_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsigneeTradeParty')
     )
   end
 
   def consignee_postal_address
     trade_party_postal_address(
-      specified_supply_chain_consignment[:consignee_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsigneeTradeParty')
     )
   end
 
@@ -63,7 +63,7 @@ class Permit
 
   def consignee_country
     trade_party_country(
-      specified_supply_chain_consignment[:consignee_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsigneeTradeParty')
     )
   end
 
@@ -72,49 +72,49 @@ class Permit
   # TODO: where does this go?
   def consignor_id
     trade_party_id(
-      specified_supply_chain_consignment[:consignor_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsignorTradeParty')
     )
   end
 
   def consignor_name
     trade_party_name(
-      specified_supply_chain_consignment[:consignor_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsignorTradeParty')
     )
   end
 
   def consignor_postal_address
     trade_party_postal_address(
-      specified_supply_chain_consignment[:consignor_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsignorTradeParty')
     )
   end
 
   def consignor_country
     trade_party_country(
-      specified_supply_chain_consignment[:consignor_trade_party]
+      specified_supply_chain_consignment.at_xpath('urn1:ConsignorTradeParty')
     )
   end
 
   # Box 5a
 
   def purpose
-    header_exchanged_document[:purpose]
+    header_exchanged_document.at_xpath('urn1:Purpose').content
   end
 
   # always present
   def purpose_code
-    header_exchanged_document[:purpose_code]
+    header_exchanged_document.at_xpath('urn1:PurposeCode').content
   end
 
   # Box 5
 
   def special_conditions
-    header_exchanged_document[:information]
+    header_exchanged_document.at_xpath('urn1:Information').content
   end
 
   # Box 5b
 
   def security_stamp_no
-    first_signatory_document_authentication[:id]
+    first_signatory_document_authentication.at_xpath('urn1:ID').content
   end
 
   # Box 6
@@ -122,76 +122,76 @@ class Permit
   # TODO: where does this go?
   def issuing_authority_id
     trade_party_id(
-      first_signatory_document_authentication[:provider_trade_party]
+      first_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty')
     )
   end
 
   def issuing_authority_name
     trade_party_name(
-      first_signatory_document_authentication[:provider_trade_party]
+      first_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty')
     )
   end
 
   def issuing_authority_postal_address
     trade_party_postal_address(
-      first_signatory_document_authentication[:provider_trade_party]
+      first_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty')
     )
   end
 
   def issuing_authority_country
     trade_party_country(
-      first_signatory_document_authentication[:provider_trade_party]
+      first_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty')
     )
   end
 
   def issuing_authority_representative_person
-    first_signatory_document_authentication[:provider_trade_party][:specified_representative_person][:name]
+    first_signatory_document_authentication.at_xpath('urn1:ProviderTradeParty/urn1:SpecifiedRepresentativePerson/urn1:Name').content
   end
 
   # Box 13
 
   def issue_place
-    header_exchanged_document[:issue_logistics_location][:name]
+    header_exchanged_document.at_xpath('urn1:IssueLogisticsLocation/urn1:Name').content
   end
 
   # always present
   def issue_date_time
-    header_exchanged_document[:issue_date_time]
+    header_exchanged_document.at_xpath('urn1:IssueDateTime').content
   end
 
   private
 
   def header_exchanged_document
-    @body[:cbf_ship][:header_exchanged_document]
+    @body.xpath('//CBFShip/urn:HeaderExchangedDocument')
   end
 
   def specified_supply_chain_consignment
-    @body[:cbf_ship][:specified_supply_chain_consignment]
+    @body.xpath('//CBFShip/urn:SpecifiedSupplyChainConsignment')
   end
 
   def first_signatory_document_authentication
-    header_exchanged_document[:first_signatory_document_authentication]
+    header_exchanged_document.at_xpath('urn1:FirstSignatoryDocumentAuthentication')
   end
 
   def trade_party_id(node)
-    node[:id]
+    node.at_xpath('urn1:ID').content
   end
 
   def trade_party_name(node)
-    node[:name]
+    node.at_xpath('urn1:Name').content
   end
 
   def trade_party_postal_address(node)
-    [:street_name, :post_office_box, :city_name, :postcode_code].map do |address_part|
-      node[:postal_trade_address][address_part]
+    ['StreetName', 'PostOfficeBox', 'CityName', 'PostcodeCode'].map do |address_part|
+      node.at_xpath("urn1:PostalTradeAddress/urn1:#{address_part}").content
     end.compact.join(', ')
   end
 
   def trade_party_country(node)
-    parts = [:id, :name].map do |country_name_part|
-      node[:postal_trade_address][:country_identification_trade_country][country_name_part]
+    parts = ['ID', 'Name'].map do |country_name_part|
+      node.at_xpath("urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:#{country_name_part}").content
     end
-    parts << node[:postal_trade_address][:country_identification_trade_country][:subordinate_trade_country_sub_division][:name]
+    parts << node.at_xpath('urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:SubordinateTradeCountrySubDivision/urn1:Name').content
     parts.compact.join(', ')
   end
 end

--- a/lib/modules/permit_line_item.rb
+++ b/lib/modules/permit_line_item.rb
@@ -1,0 +1,137 @@
+class PermitLineItem
+
+  # Initialise using XML body of permit line item
+  def initialize(body)
+    @body = body
+  end
+
+  def id
+    @body.at_xpath('urn1:ID').content
+  end
+
+  # Box 7
+
+  def scientific_name
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:SpecifiedTradeProduct/urn1:ScientificName').content
+  end
+
+  # Box 8
+
+  def common_name
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:SpecifiedTradeProduct/urn1:CommonName').content
+  end
+
+  # Box 9
+
+  def term
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:SpecifiedTradeProduct/urn1:Description').content
+  end
+
+  def term_code
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:SpecifiedTradeProduct/urn1:TypeCode').content
+  end
+
+  # TODO: in CITES Toolkit v2 there's an additional element for markings called PhysicalLogisticsShippingMarks
+
+  # Box 10
+
+  def appendix
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:TypeCode').content
+  end
+
+  def source
+    @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:TypeExtensionCode').content
+  end
+
+  # Box 11
+
+  def quantity
+    @body.at_xpath('urn1:TransportLogisticsPackage/urn1:ItemQuantity').content
+  end
+
+  def unit_code
+    @body.at_xpath('urn1:TransportLogisticsPackage/urn1:ItemQuantity').attribute('unitCode')
+  end
+
+  # Box 11a
+
+  def used_to_date_quantity
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:UsedToDateQuotaQuantity').content
+  end
+
+  def used_to_date_unit_code
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:UsedToDateQuotaQuantity').attribute('unitCode')
+  end
+
+  def annual_quota_quantity
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AnnualQuotaQuantity').content
+  end
+
+  def annual_quota_unit_code
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AnnualQuotaQuantity').attribute('unitCode')
+  end
+
+  # Box 12
+
+  def origin_country
+    @body.at_xpath('urn1:OriginTradeCountry/urn1:Name').content
+  end
+
+  def origin_permit_id
+    origin_permit.at_xpath('urn1:ID').content
+  end
+
+  def origin_permit_date
+    origin_permit.at_xpath('urn1:IssueDateTime').content
+  end
+
+  # Box 12a
+
+  def export_country
+    @body.at_xpath('urn1:ExportTradeCountry/urn1:Name').content
+  end
+
+  def export_permit_id
+    export_permit.at_xpath('urn1:ID').content
+  end
+
+  def export_permit_date
+    export_permit.at_xpath('urn1:IssueDateTime').content
+  end
+
+  # Box 12b
+
+  # TODO: in CITES Toolkit v2 there's an additional element for this called CategoryCode
+  def operation_no
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AcquisitionDateTime').content
+  end
+
+  # Box 14
+
+  def final_quantity
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').content
+  end
+
+  def final_unit_code
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').attribute('unitCode')
+  end
+
+  private
+
+  def associated_referenced_documents
+    @body.xpath('urn1:AssociatedReferencedDocument')
+  end
+
+  def origin_permit
+    # TODO this is completely bonkers, basically trying to make it work with buggy data
+    # TypeCode should be one of Export, Re-export, Import or Other
+    associated_referenced_documents.select{|ard| ard.at_xpath('urn1:TypeCode').content == '861'}.first
+  end
+
+  def export_permit
+    # TODO this is completely bonkers, basically trying to make it work with buggy data
+    # TypeCode should be one of Export, Re-export, Import or Other
+    associated_referenced_documents.select{|ard| ard.at_xpath('urn1:TypeCode').content == '811'}.first
+  end
+
+end


### PR DESCRIPTION
This populates the permit details page with values fetched from our dummy WS. Unfortunately, the sample data we have is not of great quality - some fields are missing and some seem to be incorrectly coded in the XML document. We'll need to get better quality examples to understand the semantics of some of the fields better, and also probably we will need 2 versions of this mapping to support CITES Toolkit versions 1 & 2. This mapping is compliant with CITES Toolkit 1 to make the example work.

I left out specs to avoid reworking them when we get better quality data samples.
