### PR TITLE
Error handling

### DIFF
--- a/app/assets/stylesheets/shared/colors.scss
+++ b/app/assets/stylesheets/shared/colors.scss
@@ -7,3 +7,5 @@ $extralight-grey: #e7e7e7;
 $cream: #f7f7f7;
 $main-blue: #405687;
 $dark-blue: #374973;
+$red: #d80600;
+$dark-red: #ac0401;

--- a/app/assets/stylesheets/shared/components.scss
+++ b/app/assets/stylesheets/shared/components.scss
@@ -39,3 +39,11 @@
   background-image: linear-gradient(to bottom, $extralight-grey 0, $light-grey 100%);
   background-repeat: repeat-x;
 }
+
+.alert-error {
+  background-image: -webkit-linear-gradient(top, $red 0, $dark-red 100%);
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, $red), to($dark-red));
+  background-image: linear-gradient(to bottom, $red 0, $dark-red 100%);
+  background-repeat: repeat-x;
+  color: white;
+}

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::BaseController < ApplicationController
   private
 
   def soap_adapter_exception(e)
-    if e.message == "Timeout::Error"
+    if e.cause.is_a?(Timeout::Error)
       render_soap_error 'This request took too long to process...'
     else
       render_soap_error 'Something went wrong'

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,2 +1,14 @@
 class Api::V1::BaseController < ApplicationController
+  rescue_from Adapters::SoapAdapterException, with: :soap_adapter_exception
+
+  private
+
+  def soap_adapter_exception(e)
+    if e.message == "Timeout::Error"
+      render_soap_error 'This request took too long to process...'
+    else
+      render_soap_error 'Something went wrong'
+    end
+  end
+
 end

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -7,7 +7,9 @@ class Api::V1::SoapApiController < Api::V1::BaseController
 
   before_action :load_adapter
 
-  soap_action 'get_final_cites_certificate',
+  rescue_from Adapters::AdapterException, with: :adapter_exception
+
+  soap_action :get_final_cites_certificate,
               args: {
                 CertificateNumber: :string,
                 TokenId: :string,
@@ -18,7 +20,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
   end
 
-  soap_action 'get_non_final_cites_certificate',
+  soap_action :get_non_final_cites_certificate,
               args: {
                 CertificateNumber: :string,
                 TokenId: :string,
@@ -29,7 +31,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
   end
 
-  soap_action 'confirm_quantities',
+  soap_action :confirm_quantities,
               args: {
                 CertificateNumber: :string,
                 TokenId: :string,
@@ -45,7 +47,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     end
   end
 
-  soap_action 'service_state',
+  soap_action :service_state,
               args: {},
               return: :string
   def service_state
@@ -59,9 +61,17 @@ class Api::V1::SoapApiController < Api::V1::BaseController
       joins(:country).where('countries.iso_code2' => params[:IsoCountryCode]).
       first
     unless organisation.present?
-      raise WashOut::Dispatcher::SOAPError, "AdapterNotFound"
+      render_soap_error "AdapterNotFound"
     else
       @adapter = organisation.adapter
+    end
+  end
+
+  def adapter_exception(e)
+    if e.message == "Timeout::Error"
+      render_soap_error 'This request took too long to process...'
+    else
+      render_soap_error 'Something went wrong'
     end
   end
 

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     if WashOut::Types::CitesPositionsType.valid?(params[:ConfirmedQuantities][:CitesPosition])
       render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
     else
-      render soap: "XML structure is not valid. ID must be a token"
+      render_soap_error "XML structure is not valid. ID must be a token", "Client"
     end
   end
 

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
               },
               return: :string
   def get_final_cites_certificate
-    render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
+    render xml: Adapters::SimpleAdapter.run(@adapter, params).to_xml
   end
 
   soap_action :get_non_final_cites_certificate,
@@ -26,7 +26,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
               },
               return: :string
   def get_non_final_cites_certificate
-    render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
+    render xml: Adapters::SimpleAdapter.run(@adapter, params).to_xml
   end
 
   soap_action :confirm_quantities,
@@ -39,7 +39,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
               return: :string
   def confirm_quantities
     if WashOut::Types::CitesPositionsType.valid?(params[:ConfirmedQuantities][:CitesPosition])
-      render xml: Adapters::SimpleAdapter.run(@adapter).to_xml
+      render xml: Adapters::SimpleAdapter.run(@adapter, params).to_xml
     else
       render_soap_error "XML structure is not valid. ID must be a token", "Client"
     end

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -5,7 +5,9 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     return user.valid_password?(password)
   }
 
-  before_action :load_adapter
+  before_action do
+    load_adapter if request.original_url.split('/').last != 'wsdl'
+  end
 
   soap_action :get_final_cites_certificate,
               args: {

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -7,8 +7,6 @@ class Api::V1::SoapApiController < Api::V1::BaseController
 
   before_action :load_adapter
 
-  rescue_from Adapters::AdapterException, with: :adapter_exception
-
   soap_action :get_final_cites_certificate,
               args: {
                 CertificateNumber: :string,
@@ -66,13 +64,4 @@ class Api::V1::SoapApiController < Api::V1::BaseController
       @adapter = organisation.adapter
     end
   end
-
-  def adapter_exception(e)
-    if e.message == "Timeout::Error"
-      render_soap_error 'This request took too long to process...'
-    else
-      render_soap_error 'Something went wrong'
-    end
-  end
-
 end

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -5,9 +5,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     return user.valid_password?(password)
   }
 
-  before_action do
-    load_adapter if request.original_url.split('/').last != 'wsdl'
-  end
+  before_action :load_adapter, except: :_generate_wsdl
 
   soap_action :get_final_cites_certificate,
               args: {

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -48,12 +48,11 @@ class PermitsController < ApplicationController
   end
 
   def soap_adapter_exception(e)
-    message = ''
-    if e.message == "Timeout::Error"
-      message = 'This request took too long to be processed...'
-    else
-      message = 'Something went wrong'
-    end
+    message = if e.cause.is_a?(Timeout::Error)
+                'This request took too long to be processed...'
+              else
+                'Something went wrong'
+              end
     redirect_to permits_path, flash: { error: message }
   end
 

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -2,6 +2,8 @@ class PermitsController < ApplicationController
   before_action :sanitise_params, only: [:index, :show]
   before_action :load_adapter, only: [:show]
 
+  rescue_from Adapters::SoapAdapterException, with: :soap_adapter_exception
+
   def index
     if @country && @permit_identifier
       redirect_to(permit_path(
@@ -43,6 +45,16 @@ class PermitsController < ApplicationController
       redirect_to(permits_path) && return
     end
     @adapter = organisation.adapter
+  end
+
+  def soap_adapter_exception(e)
+    message = ''
+    if e.message == "Timeout::Error"
+      message = 'This request took too long to be processed...'
+    else
+      message = 'Something went wrong'
+    end
+    redirect_to permits_path, flash: { error: message }
   end
 
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -92,4 +92,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.wash_out.camelize_wsdl = true
+  config.wash_out.parser = :nokogiri
 end

--- a/lib/modules/adapters/adapter_exception.rb
+++ b/lib/modules/adapters/adapter_exception.rb
@@ -1,2 +1,0 @@
-class Adapters::AdapterException < StandardError
-end

--- a/lib/modules/adapters/adapter_exception.rb
+++ b/lib/modules/adapters/adapter_exception.rb
@@ -1,0 +1,2 @@
+class Adapters::AdapterException < StandardError
+end

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -21,13 +21,7 @@ class Adapters::Base
     operation = @params[:operation]
     auth = @params[:auth]
     timeout = @params[:timeout]
-    begin
-      Timeout::timeout(timeout) {
-        Transports::Soap.request(wsdl, operation, auth, message)
-      }
-    rescue => e
-      raise Adapters::SoapAdapterException, e.class
-    end
+    Transports::Soap.request(wsdl, operation, timeout, auth, message)
   end
 
   def rest_request(message = {})

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -26,7 +26,7 @@ class Adapters::Base
         Transports::Soap.request(wsdl, operation, auth, message)
       }
     rescue => e
-      raise Adapters::AdapterException, e.class
+      raise Adapters::SoapAdapterException, e.class
     end
   end
 

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -26,11 +26,7 @@ class Adapters::Base
         Transports::Soap.request(wsdl, operation, auth, message)
       }
     rescue => e
-      if e.is_a?(Timeout::Error)
-        p 'This request took too long to process...'
-      else
-        p 'Something went wrong'
-      end
+      raise Adapters::AdapterException, e.class
     end
   end
 

--- a/lib/modules/adapters/soap_adapter_exception.rb
+++ b/lib/modules/adapters/soap_adapter_exception.rb
@@ -1,0 +1,2 @@
+class Adapters::SoapAdapterException < StandardError
+end

--- a/lib/modules/transports/soap.rb
+++ b/lib/modules/transports/soap.rb
@@ -1,9 +1,15 @@
 class Transports::Soap < Transports::Base
 
-  def self.request(wsdl, operation, auth={}, options={})
-    client = get_client(wsdl, auth)
+  def self.request(wsdl, operation, timeout, auth={}, message={})
+    begin
+      Timeout::timeout(timeout) {
+        client = get_client(wsdl, auth)
 
-    result = client.call(operation, message: options)
+        result = client.call(operation, message: message)
+      }
+    rescue => e
+      raise Adapters::SoapAdapterException, e.class
+    end
   end
 
   private

--- a/spec/modules/transports/soap_spec.rb
+++ b/spec/modules/transports/soap_spec.rb
@@ -11,10 +11,16 @@ describe Transports::Soap do
   it "returns a response using Savon" do
     wsdl = File.read(Rails.root.join("spec/fixtures/transports/", "fake.wsdl"))
     savon.expects(:say_hello).with(message: :any).returns("response")
-    service = Transports::Soap.request(wsdl, :say_hello)
+    service = Transports::Soap.request(wsdl, :say_hello, 0)
 
     expect(service).to be_successful
     expect(service.to_s).to eq("response")
+  end
 
+  it "returns a soap fault timeout error" do
+    wsdl = File.read(Rails.root.join("spec/fixtures/transports/", "fake.wsdl"))
+    allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+    expect{ Transports::Soap.request(wsdl, :say_hello, 0.00001) }.
+      to raise_error(Adapters::SoapAdapterException, "Timeout::Error")
   end
 end


### PR DESCRIPTION
Improves error handling for API, Adapters and web interface.
Regarding SOAP fault responses, if the error comes from Adapters or API the error code is `Server`, otherwise if the request is not well formatted than the code is `Client`, as per official SOAP specs.

Also, the soap action names are now named back using colon. This is because I've added a configuration for the staging environment to automatically handle camelisation using WashOut, which was already present for development.
