### PR TITLE
make sure request parameter names are not tampered with by Savon

### DIFF
--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -17,9 +17,9 @@ class PermitsController < ApplicationController
   def show
     @response = Adapters::SimpleAdapter.run(
       @adapter, {
-        certificate_number: @permit_identifier,
-        token_id: '?',
-        country: @country
+        CertificateNumber: @permit_identifier,
+        TokenId: '?',
+        IsoCountryCode: @country
       }
     )
 

--- a/lib/modules/transports/soap.rb
+++ b/lib/modules/transports/soap.rb
@@ -9,11 +9,22 @@ class Transports::Soap < Transports::Base
   private
 
   def self.get_client(wsdl, auth)
-    Savon::Client.new(wsdl: wsdl) if auth.empty?
+    Savon::Client.new(
+      wsdl: wsdl,
+      convert_request_keys_to: :none
+    ) if auth.empty?
     if auth['token_auth'].present?
-      Savon::Client.new(wsdl: wsdl, soap_header: auth[:token_auth])
+      Savon::Client.new(
+        wsdl: wsdl,
+        soap_header: auth[:token_auth],
+        convert_request_keys_to: :none
+      )
     else
-      Savon::Client.new(wsdl: wsdl, wsse_auth: [auth['username'], auth['password']])
+      Savon::Client.new(
+        wsdl: wsdl,
+        wsse_auth: [auth['username'], auth['password']],
+        convert_request_keys_to: :none
+      )
     end
   end
 end


### PR DESCRIPTION
This change is to fix the incorrect parameter names that were passed from the adapter to the web service: Savon would convert them from underscores to camelcase, but starting with lower case instead of upper case (e.g. `certificateNumber` instead of `CertificateNumber`). Since XML is case sensitive I guess it's safer to prevent Savon from alterations to the parameter names.
