### PR TITLE
Differentiate errors

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::BaseController < ApplicationController
   def soap_adapter_exception(e)
     if e.cause.is_a?(Timeout::Error)
       render_soap_error 'This request took too long to process...'
+    elsif e.cause.is_a?(Savon::SOAPFault)
+      render xml: e.cause.xml
     else
       render_soap_error 'Something went wrong'
     end

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -50,6 +50,11 @@ class PermitsController < ApplicationController
   def soap_adapter_exception(e)
     message = if e.cause.is_a?(Timeout::Error)
                 'This request took too long to be processed...'
+              elsif e.cause.is_a?(Savon::SOAPFault)
+                """
+                Something went wrong:
+                #{e.cause.to_hash[:fault][:details][:cites_data_exchange_fault][:error_message]}
+                """
               else
                 'Something went wrong'
               end


### PR DESCRIPTION
If the error comes from the WS, then we render the SOAP Fault as is, otherwise we render a general error.
The error message is also displayed in the online interface when using the permit search functionality.
