### PR TITLE
Required permit

### DIFF
--- a/app/views/permits/index.html.erb
+++ b/app/views/permits/index.html.erb
@@ -14,7 +14,7 @@
       <%= label_tag(:permit_identifier, t('enter_permit_identifier')) %>
       <%= text_field_tag(
         :permit_identifier, nil,
-        {class: 'form-control', placeholder: t('permit_identifier')}
+        {class: 'form-control', placeholder: t('permit_identifier'), required: true}
       )%>
     </div>
     <div class="form-group text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
     constraint: { country: /\w\w/ }
   resources :permits, only: [:index]
 
+  get 'permits/:country/' => redirect('permits/')
+
   namespace :admin do
     resources :organisations, except: [:destroy]
     resources :users


### PR DESCRIPTION
If permit identifier is blank when searching for a permit, then do not trigger the search but notify the user to fill the input.
Redirect any url of the format `permits/:country` to permits index page.
