### PR TITLE
Sync countries with splus

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -22,6 +22,8 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/passenger'
+require 'whenever/capistrano'
+
 
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'wash_out'
 gem 'attr_encrypted', '~>3.0.0'
 gem 'cancancan', '~> 1.10'
 gem 'nokogiri'
+gem 'whenever', require: false
 
 group :development do
   # Docs

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'attr_encrypted', '~>3.0.0'
 gem 'cancancan', '~> 1.10'
 gem 'nokogiri'
 gem 'whenever', require: false
+gem 'httparty'
 
 group :development do
   # Docs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       activesupport (>= 4.1.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     httpi (2.4.2)
       rack
       socksify
@@ -138,6 +140,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    multi_xml (0.5.5)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
@@ -281,6 +284,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   font-awesome-rails
+  httparty
   jquery-rails
   letter_opener
   nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    chronic (0.10.2)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coffee-rails (4.2.1)
@@ -255,6 +256,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -293,6 +296,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   wash_out
   web-console (~> 2.0)
+  whenever
   yard (~> 0.8.7.6)
 
 BUNDLED WITH

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,3 +28,5 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
 set :keep_releases, 5
 
 set :passenger_restart_with_touch, false
+
+set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 30.days do
+  rake "sync:countries"
+end

--- a/lib/tasks/sync_countries.rake
+++ b/lib/tasks/sync_countries.rake
@@ -1,6 +1,6 @@
 namespace :sync do
   task :countries => :environment do
-    response = HTTParty.get('http://speciesplus.net/api/v1/geo_entities')
+    response = HTTParty.get('http://speciesplus.net/api/v1/geo_entities?geo_entity_types_set=3')
     unless response.code == 200
       Rails.logger.info "Something went wrong while fetching countries"
       Rails.logger.info "Message: #{response.message}"

--- a/lib/tasks/sync_countries.rake
+++ b/lib/tasks/sync_countries.rake
@@ -1,0 +1,32 @@
+namespace :sync do
+  task :countries => :environment do
+    response = HTTParty.get('http://speciesplus.net/api/v1/geo_entities')
+    unless response.code == 200
+      Rails.logger.info "Something went wrong while fetching countries"
+      Rails.logger.info "Message: #{response.message}"
+    end
+    geo_entities = response["geo_entities"]
+    geo_entities.each do |geo_entity|
+      if geo_entity["geo_entity_type"] == "COUNTRY"
+        id = geo_entity["id"]
+        name = geo_entity["name"]
+        iso_code2 = geo_entity["iso_code2"]
+        country = Country.find_by_id(id)
+        if country.present?
+          updated = false
+          if name != country.name
+            country.update_attributes(name: name)
+            updated = true
+          elsif iso_code2 != country.iso_code2
+            country.update_attributes(iso_code2: iso_code2) unless iso_code2 != country.iso_code2
+            updated = true
+          end
+          Rails.logger.info "Country with ID: #{id} has been updated!" if updated
+        else
+          Country.create({id: id, name: geo_entity["name"], iso_code2: geo_entity["iso_code2"]})
+          Rails.logger.info "Country with name: #{name} has been created!"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will synchronise the list of countries with the list already present in Species+.
The rake task will run every 30 days using `whenever`.
The httparty client fetches the countries from the Species+ API and the synchronisation is done considering the ID of the country. If the country is already present then it checks if the name or the iso_code2 is different and updates it, otherwise it creates the country.

The default environment for whenever is set to production, so for testing it it's necessary to change it to staging adding `set :environment, 'staging'` on top of the `schedule.rb` file.
