### PR TITLE
Ssl request to dummy ws

### DIFF
--- a/db/migrate/20160916125555_add_skip_ssl_verification_to_adapters.rb
+++ b/db/migrate/20160916125555_add_skip_ssl_verification_to_adapters.rb
@@ -1,0 +1,5 @@
+class AddSkipSslVerificationToAdapters < ActiveRecord::Migration[5.0]
+  def change
+    add_column :adapters, :skip_ssl_verification, :boolean, default: true
+  end
+end

--- a/lib/modules/adapters/base.rb
+++ b/lib/modules/adapters/base.rb
@@ -21,7 +21,8 @@ class Adapters::Base
     operation = @params[:operation]
     auth = @params[:auth]
     timeout = @params[:timeout]
-    Transports::Soap.request(wsdl, operation, timeout, auth, message)
+    skip_ssl_verification = @params[:skip_ssl_verification]
+    Transports::Soap.request(wsdl, operation, timeout, auth, skip_ssl_verification, message)
   end
 
   def rest_request(message = {})

--- a/lib/modules/adapters/simple_adapter.rb
+++ b/lib/modules/adapters/simple_adapter.rb
@@ -17,7 +17,8 @@ class Adapters::SimpleAdapter < Adapters::Base
       auth: {
         username: '',
         password: ''
-      }
+      },
+      skip_ssl_verification: adapter.skip_ssl_verification
     }
   end
 end

--- a/lib/modules/transports/soap.rb
+++ b/lib/modules/transports/soap.rb
@@ -18,6 +18,7 @@ class Transports::Soap < Transports::Base
     common_options = {
       wsdl: wsdl,
       convert_request_keys_to: :none,
+      ssl_verify_mode: :none # TODO: temporary self-signed cert for dummy WS
     }
     Savon::Client.new(common_options) if auth.empty?
     if auth['token_auth'].present?

--- a/lib/modules/transports/soap.rb
+++ b/lib/modules/transports/soap.rb
@@ -15,21 +15,22 @@ class Transports::Soap < Transports::Base
   private
 
   def self.get_client(wsdl, auth)
-    Savon::Client.new(
+    common_options = {
       wsdl: wsdl,
-      convert_request_keys_to: :none
-    ) if auth.empty?
+      convert_request_keys_to: :none,
+    }
+    Savon::Client.new(common_options) if auth.empty?
     if auth['token_auth'].present?
       Savon::Client.new(
-        wsdl: wsdl,
-        soap_header: auth[:token_auth],
-        convert_request_keys_to: :none
+        common_options.merge({
+          soap_header: auth[:token_auth]
+        })
       )
     else
       Savon::Client.new(
-        wsdl: wsdl,
-        wsse_auth: [auth['username'], auth['password']],
-        convert_request_keys_to: :none
+        common_options.merge({
+          wsse_auth: [auth['username'], auth['password']]
+        })
       )
     end
   end


### PR DESCRIPTION
I configured SSL connection to the test web service. The change required to make epix connect to it through the encrypted channel is to change the web service uri, but in this case, because I set up a self-signed certificate which cannot be verified, Savon raises an error unless SSL verification is turned off. I expect it will be a common case while we're in testing stage that we won't be dealing with real certificates, therefore I added a new flag to the adapters table to indicate that.
