### PR TITLE
Cites toolkit v2 compatibility

### DIFF
--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -68,7 +68,7 @@ class PermitsController < ApplicationController
               else
                 'Something went wrong'
               end
-    redirect_to permits_path, flash: { alert: message }
+    redirect_to permits_path, flash: { error: message }
   end
 
 

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -26,7 +26,11 @@ class PermitsController < ApplicationController
     )
 
     xml = Nokogiri::XML(@response.to_xml)
-    @permit = Cites::V1::Permit.new(xml)
+    @permit = if @adapter.cites_toolkit_v2?
+      Cites::V2::Permit.new(xml)
+    else
+      Cites::V1::Permit.new(xml)
+    end
   end
 
   private

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -26,7 +26,7 @@ class PermitsController < ApplicationController
     )
 
     xml = Nokogiri::XML(@response.to_xml)
-    @permit = Permit.new(xml)
+    @permit = Cites::V1::Permit.new(xml)
   end
 
   private

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -27,10 +27,10 @@ class PermitsController < ApplicationController
 
     xml = Nokogiri::XML(@response.to_xml)
     @permit = if @adapter.cites_toolkit_v2?
-      Cites::V2::Permit.new(xml)
-    else
-      Cites::V1::Permit.new(xml)
-    end
+                Cites::V2::Permit.new(xml)
+              else
+                Cites::V1::Permit.new(xml)
+              end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+
+  # parses datetime string and returns date string
   def date_format(datetime_string)
     begin
       Date.parse(datetime_string).strftime("%d-%m-%Y")

--- a/app/models/adapter.rb
+++ b/app/models/adapter.rb
@@ -4,4 +4,8 @@ class Adapter < ApplicationRecord
   attr_encrypted :auth_password, key: Rails.application.secrets.adapter["auth_password_key"]
 
   belongs_to :organisation
+
+  def cites_toolkit_v2?
+    cites_toolkit_version == 2
+  end
 end

--- a/app/views/permits/_species_details_block.html.erb
+++ b/app/views/permits/_species_details_block.html.erb
@@ -18,6 +18,7 @@
             <div class="permit-value">
               <%= line_item.term %>
               <%= line_item.term_code %>
+              <%= line_item.markings %>
             </div>
           </div>
         </div>
@@ -96,7 +97,9 @@
           12b. <%= t('operation_no') %>
         </div>
         <div class="permit-value">
-          <%= date_format(line_item.operation_no) %>
+          <%= line_item.category_code %>
+          <%= date_format(line_item.acquisition_date_time) %>
+          <%= line_item.operation_no %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,12 @@ Rails.application.routes.draw do
   # See how all your routes lay out with "rake routes".
   get 'permits/:country/:permit_identifier' => 'permits#show',
     as: 'permit',
-    constraint: { country: /\w\w/ }
+    country: /\w\w/
+  # in case country malformed
+  get 'permits/:country/:permit_identifier' => redirect('permits/')
+  # in case permit number not given
+  get 'permits/:country' => redirect('permits/')
   resources :permits, only: [:index]
-
-  get 'permits/:country/' => redirect('permits/')
 
   namespace :admin do
     resources :organisations, except: [:destroy]

--- a/db/migrate/20160919114622_add_cites_toolkit_version_to_adapters.rb
+++ b/db/migrate/20160919114622_add_cites_toolkit_version_to_adapters.rb
@@ -1,0 +1,5 @@
+class AddCitesToolkitVersionToAdapters < ActiveRecord::Migration[5.0]
+  def change
+    add_column :adapters, :cites_toolkit_version, :integer, null:false, default: 2
+  end
+end

--- a/lib/modules/cites/permit_line_item_mapping.rb
+++ b/lib/modules/cites/permit_line_item_mapping.rb
@@ -1,9 +1,4 @@
-class PermitLineItem
-
-  # Initialise using XML body of permit line item
-  def initialize(body)
-    @body = body
-  end
+module Cites::PermitLineItemMapping
 
   def id
     @body.at_xpath('urn1:ID').content
@@ -31,7 +26,9 @@ class PermitLineItem
     @body.at_xpath('urn1:IncludedSupplyChainTradeLineItem/urn1:SpecifiedTradeProduct/urn1:TypeCode').content
   end
 
-  # TODO: in CITES Toolkit v2 there's an additional element for markings called PhysicalLogisticsShippingMarks
+  def markings
+    @body.at_xpath('urn1:PhysicalLogisticsShippingMarks/urn1:Marking').content
+  end
 
   # Box 10
 
@@ -56,19 +53,19 @@ class PermitLineItem
   # Box 11a
 
   def used_to_date_quantity
-    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:UsedToDateQuotaQuantity').content
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:UsedToDateQuotaQuantity').content
   end
 
   def used_to_date_unit_code
-    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:UsedToDateQuotaQuantity').attribute('unitCode')
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:UsedToDateQuotaQuantity').attribute('unitCode')
   end
 
   def annual_quota_quantity
-    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AnnualQuotaQuantity').content
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:AnnualQuotaQuantity').content
   end
 
   def annual_quota_unit_code
-    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AnnualQuotaQuantity').attribute('unitCode')
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:AnnualQuotaQuantity').attribute('unitCode')
   end
 
   # Box 12
@@ -101,22 +98,38 @@ class PermitLineItem
 
   # Box 12b
 
-  # TODO: in CITES Toolkit v2 there's an additional element for this called CategoryCode
+  def category_code
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:CategoryCode').content
+  end
+
+  def acquisition_date_time
+    applicable_cross_border_regulatory_procedure.at_xpath('urn1:AcquisitionDateTime').content
+  end
+
   def operation_no
-    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure/urn1:AcquisitionDateTime').content
+    previous_referenced_document = applicable_cross_border_regulatory_procedure.
+      at_xpath('urn1:PreviousReferencedDocument')
+    [
+      previous_referenced_document.at_xpath('urn1:ID'),
+      previous_referenced_document.at_xpath('urn1:Name')
+    ].map(&:content).join(', ')
   end
 
   # Box 14
 
   def final_quantity
-    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').content
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:UnitQuantity').content
   end
 
   def final_unit_code
-    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').attribute('unitCode')
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:UnitQuantity').attribute('unitCode')
   end
 
   private
+
+  def applicable_cross_border_regulatory_procedure
+    @body.at_xpath('urn1:ApplicableCrossBorderRegulatoryProcedure')
+  end
 
   def associated_referenced_documents
     @body.xpath('urn1:AssociatedReferencedDocument')

--- a/lib/modules/cites/permit_mapping.rb
+++ b/lib/modules/cites/permit_mapping.rb
@@ -1,15 +1,4 @@
-class Permit
-
-  # Initialise using XML body of permit response
-  def initialize(body)
-    @body = body
-  end
-
-  def line_items
-    specified_supply_chain_consignment.xpath('urn1:IncludedSupplyChainConsignmentItem').map do |xml|
-      PermitLineItem.new(xml)
-    end
-  end
+module Cites::PermitMapping
 
   # Box 1
 
@@ -190,11 +179,11 @@ class Permit
   private
 
   def header_exchanged_document
-    @body.xpath('//CBFShip/urn:HeaderExchangedDocument')
+    @body.xpath('//CITESEPermit/urn:HeaderExchangedDocument')
   end
 
   def specified_supply_chain_consignment
-    @body.xpath('//CBFShip/urn:SpecifiedSupplyChainConsignment')
+    @body.xpath('//CITESEPermit/urn:SpecifiedSupplyChainConsignment')
   end
 
   def first_signatory_document_authentication
@@ -220,10 +209,9 @@ class Permit
   end
 
   def trade_party_country(node)
-    parts = ['ID', 'Name'].map do |country_name_part|
-      node.at_xpath("urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:#{country_name_part}").content
-    end
-    parts << node.at_xpath('urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:SubordinateTradeCountrySubDivision/urn1:Name').content
-    parts.compact.join(', ')
+    ['CountryID', 'CountryName', 'CountrySubDivisionName'].map do |country_name_part|
+      node.at_xpath("urn1:PostalTradeAddress/urn1:#{country_name_part}").content
+    end.compact.join(', ')
   end
+
 end

--- a/lib/modules/cites/v1/permit.rb
+++ b/lib/modules/cites/v1/permit.rb
@@ -1,0 +1,32 @@
+class Cites::V1::Permit
+  include Cites::PermitMapping
+
+  # Initialise using XML body of permit response
+  def initialize(body)
+    @body = body
+  end
+
+  def line_items
+    specified_supply_chain_consignment.xpath('urn1:IncludedSupplyChainConsignmentItem').map do |xml|
+      Cites::V1::PermitLineItem.new(xml)
+    end
+  end
+
+  private
+
+  def header_exchanged_document
+    @body.xpath('//CBFShip/urn:HeaderExchangedDocument')
+  end
+
+  def specified_supply_chain_consignment
+    @body.xpath('//CBFShip/urn:SpecifiedSupplyChainConsignment')
+  end
+
+  def trade_party_country(node)
+    parts = ['ID', 'Name'].map do |country_name_part|
+      node.at_xpath("urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:#{country_name_part}").content
+    end
+    parts << node.at_xpath('urn1:PostalTradeAddress/urn1:CountryIdentificationTradeCountry/urn1:SubordinateTradeCountrySubDivision/urn1:Name').content
+    parts.compact.join(', ')
+  end
+end

--- a/lib/modules/cites/v1/permit_line_item.rb
+++ b/lib/modules/cites/v1/permit_line_item.rb
@@ -1,0 +1,33 @@
+class Cites::V1::PermitLineItem
+  include Cites::PermitLineItemMapping
+
+  # Initialise using XML body of permit line item
+  def initialize(body)
+    @body = body
+  end
+
+  # Box 9
+
+  def markings; ''; end
+
+  # Box 12b
+
+  def category_code; ''; end
+
+  # Box 14
+
+  def final_quantity
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').content
+  end
+
+  def final_unit_code
+    @body.at_xpath('urn1:ExaminationTransportEvent/urn1:InspectedUnitQuantity').attribute('unitCode')
+  end
+
+  private
+
+  def applicable_cross_border_regulatory_procedure
+    @body.at_xpath('urn1:ApplicableCrossBorderGovernmentProcedure')
+  end
+
+end

--- a/lib/modules/cites/v2/permit.rb
+++ b/lib/modules/cites/v2/permit.rb
@@ -1,0 +1,15 @@
+class Cites::V2::Permit
+  include Cites::PermitMapping
+
+  # Initialise using XML body of permit response
+  def initialize(body)
+    @body = body
+  end
+
+  def line_items
+    specified_supply_chain_consignment.xpath('urn1:IncludedSupplyChainConsignmentItem').map do |xml|
+      Cites::V2::PermitLineItem.new(xml)
+    end
+  end
+
+end

--- a/lib/modules/cites/v2/permit_line_item.rb
+++ b/lib/modules/cites/v2/permit_line_item.rb
@@ -1,0 +1,9 @@
+class Cites::V2::PermitLineItem
+  include Cites::PermitLineItemMapping
+
+  # Initialise using XML body of permit line item
+  def initialize(body)
+    @body = body
+  end
+
+end

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
 
     describe "GET edit" do
       it "has a 200 status code" do
-        get :edit, id: FactoryGirl.create(:cites_ma).id
+        get :edit, params: {id: FactoryGirl.create(:cites_ma).id}
         expect(response.status).to eq(200)
       end
     end
 
     describe "GET show" do
       it "has a 200 status code" do
-        get :show, id: FactoryGirl.create(:cites_ma).id
+        get :show, params: {id: FactoryGirl.create(:cites_ma).id}
         expect(response.status).to eq(200)
       end
     end
@@ -51,7 +51,9 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
     describe "PATCH update" do
       it "updates an organisation's role" do
         organisation = FactoryGirl.create(:cites_ma)
-        patch :update, id: organisation.id, organisation: { role: Organisation::SYSTEM_MANAGERS }
+        patch :update, params: {
+          id: organisation.id, organisation: {role: Organisation::SYSTEM_MANAGERS}
+        }
         organisation.reload
         expect(organisation.role).to eq(Organisation::SYSTEM_MANAGERS)
         expect(response.status).to eq(302)
@@ -74,7 +76,9 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
         organisation = subject.current_user.organisation
         old_name = organisation.name
         new_name = old_name + ' ZONK'
-        patch :update, id: organisation.id, organisation: { name: new_name }
+        patch :update, params: {
+          id: organisation.id, organisation: {name: new_name}
+        }
         organisation.reload
         expect(organisation.name).to eq(new_name)
         expect(response.status).to eq(302)
@@ -82,14 +86,18 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
       it "does not update another organisation's name" do
         organisation = FactoryGirl.create(:cites_ma)
         old_name = organisation.name
-        patch :update, id: organisation.id, organisation: { name: old_name + ' ZONK' }
+        patch :update, params: {
+          id: organisation.id, organisation: {name: old_name + ' ZONK'}
+        }
         organisation.reload
         expect(organisation.name).to eq(old_name)
         expect(response.status).to eq(302)
       end
       it "does not update own organisation's role" do
         organisation = subject.current_user.organisation
-        patch :update, id: organisation.id, organisation: { role: Organisation::SYSTEM_MANAGERS }
+        patch :update, params: {
+          id: organisation.id, organisation: {role: Organisation::SYSTEM_MANAGERS}
+        }
         organisation.reload
         expect(organisation.role).to eq(Organisation::CITES_MA)
         expect(response.status).to eq(302)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe "GET edit" do
       it "has a 200 status code" do
-        get :edit, id: same_org_user.id
+        get :edit, params: {id: same_org_user.id}
         expect(response.status).to eq(200)
       end
     end
 
     describe "GET show" do
       it "has a 200 status code" do
-        get :show, id: same_org_user.id
+        get :show, params: {id: same_org_user.id}
         expect(response.status).to eq(200)
       end
     end
@@ -58,7 +58,9 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe "PATCH update" do
       it "updates a user" do
-        patch :update, id: same_org_user.id, user: { first_name: 'asd'}
+        patch :update, params: {
+          id: same_org_user.id, user: {first_name: 'asd'}
+        }
         same_org_user.reload
         expect(same_org_user.first_name).to eq('asd')
         expect(response.status).to eq(302)
@@ -68,7 +70,7 @@ RSpec.describe Admin::UsersController, type: :controller do
     describe "DELETE destroy" do
       it "destroys a user" do
         expect do
-          delete :destroy, id: same_org_user.id
+          delete :destroy, params: {id: same_org_user.id}
         end.to change{ User.count }
 
         expect(response.status).to eq(302)
@@ -94,7 +96,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         user = subject.current_user
         old_last_name = user.last_name
         new_last_name = user.last_name + 'ZONK'
-        patch :update, id: user.id, user: { last_name: new_last_name}
+        patch :update, params: {
+          id: user.id, user: {last_name: new_last_name}
+        }
         user.reload
         expect(user.last_name).to eq(new_last_name)
         expect(response.status).to eq(302)
@@ -104,7 +108,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         other_user = FactoryGirl.create(:user, organisation: user.organisation)
         old_last_name = other_user.last_name
         new_last_name = other_user.last_name + 'ZONK'
-        patch :update, id: other_user.id, user: { last_name: new_last_name}
+        patch :update, params: {
+          id: other_user.id, user: {last_name: new_last_name}
+        }
         other_user.reload
         expect(other_user.last_name).to eq(new_last_name)
         expect(response.status).to eq(302)
@@ -114,7 +120,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         other_user = FactoryGirl.create(:user, organisation: FactoryGirl.create(:organisation))
         old_last_name = other_user.last_name
         new_last_name = other_user.last_name + 'ZONK'
-        patch :update, id: other_user.id, user: { last_name: new_last_name}
+        patch :update, params: {
+          id: other_user.id, user: {last_name: new_last_name}
+        }
         other_user.reload
         expect(other_user.last_name).to eq(old_last_name)
         expect(response.status).to eq(302)
@@ -123,7 +131,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         user = subject.current_user
         old_organisation = user.organisation
         new_organisation = FactoryGirl.create(:organisation)
-        patch :update, id: user.id, user: { organisation_id: new_organisation.id }
+        patch :update, params: {
+          id: user.id, user: {organisation_id: new_organisation.id}
+        }
         user.reload
         expect(user.organisation_id).to eq(old_organisation.id)
         expect(response.status).to eq(302)
@@ -140,7 +150,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         user = subject.current_user
         old_last_name = user.last_name
         new_last_name = user.last_name + 'ZONK'
-        patch :update, id: user.id, user: { last_name: new_last_name}
+        patch :update, params: {
+          id: user.id, user: {last_name: new_last_name}
+        }
         user.reload
         expect(user.last_name).to eq(new_last_name)
         expect(response.status).to eq(302)

--- a/spec/controllers/permits_controller_spec.rb
+++ b/spec/controllers/permits_controller_spec.rb
@@ -1,10 +1,111 @@
 require "rails_helper"
+# require "savon/mock/spec_helper"
 
 RSpec.describe PermitsController, type: :controller do
+  # include Savon::SpecHelper
+
+  # before(:all) { savon.mock! }
+  # after(:all) { savon.unmock! }
+
   describe "GET index" do
     it "has a 200 status code" do
       get :index
       expect(response.status).to eq(200)
     end
+
+    it "redirects to permit page if country and permit identifier given" do
+      get :index, params: {country: 'CH', permit_identifier: '123'}
+      expect(response).to redirect_to(
+        permit_path(country: 'CH', permit_identifier: '123')
+      )
+    end
+  end
+
+  describe "GET show" do
+    let(:cites_ma){
+      FactoryGirl.create(:cites_ma)
+    }
+    let(:savon_response){
+      instance_double(Savon::Response)
+    }
+
+    context "when country adapter does not exist" do
+      it "redirects to permits" do
+        get :show, params: {
+          country: 'XX',
+          permit_identifier: '123'
+        }
+        expect(response).to redirect_to(permits_path)
+      end
+    end
+
+    context "when country adapter supports CITES Toolkit V1" do
+      let!(:adapter){
+        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 1)
+      }
+      let(:fixture){
+        File.read("spec/fixtures/v1/get_non_final_cites_certificate.xml")
+      }
+      it "shows a CITES Toolkit V1 Permit" do
+        expect(Adapters::SimpleAdapter).to receive(:run).and_return(savon_response)
+        expect(savon_response).to receive(:to_xml).and_return(fixture)
+        get :show, params: {
+          country: cites_ma.country.iso_code2,
+          permit_identifier: '123'
+        }
+        expect(assigns[:permit]).to be_a(Cites::V1::Permit)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when country adapter supports CITES Toolkit V2" do
+      let!(:adapter){
+        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 2)
+      }
+      let(:fixture){
+        File.read("spec/fixtures/v2/get_non_final_cites_certificate.xml")
+      }
+      it "shows a CITES Toolkit V2 Permit" do
+        expect(Adapters::SimpleAdapter).to receive(:run).and_return(savon_response)
+        expect(savon_response).to receive(:to_xml).and_return(fixture)
+        get :show, params: {
+          country: cites_ma.country.iso_code2,
+          permit_identifier: '123'
+        }
+        expect(assigns[:permit]).to be_a(Cites::V2::Permit)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when connection times out" do
+      let!(:adapter){
+        FactoryGirl.create(:adapter)
+      }
+      it "redirects to permits with an error" do
+        allow_any_instance_of(Savon::Client).to receive(:call).and_raise(Timeout::Error)
+        get :show, params: {
+          country: cites_ma.country.iso_code2,
+          permit_identifier: '123'
+        }
+        expect(response).to redirect_to(permits_path)
+        expect(flash[:error]).to eq('This request took too long to be processed...')
+      end
+    end
+
+    context "when some other error" do
+      let!(:adapter){
+        FactoryGirl.create(:adapter)
+      }
+      it "redirects to permits with an error" do
+        allow_any_instance_of(Savon::Client).to receive(:call).and_raise(StandardError)
+        get :show, params: {
+          country: cites_ma.country.iso_code2,
+          permit_identifier: '123'
+        }
+        expect(response).to redirect_to(permits_path)
+        expect(flash[:error]).to eq('Something went wrong')
+      end
+    end
+
   end
 end

--- a/spec/controllers/permits_controller_spec.rb
+++ b/spec/controllers/permits_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe PermitsController, type: :controller do
   end
 
   describe "GET show" do
+    login_user
+
     let(:cites_ma){
       FactoryGirl.create(:cites_ma)
     }
@@ -42,7 +44,10 @@ RSpec.describe PermitsController, type: :controller do
 
     context "when country adapter supports CITES Toolkit V1" do
       let!(:adapter){
-        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 1)
+        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 1,
+                             countries_with_access_ids:
+                               [subject.current_user.organisation.country_id]
+                          )
       }
       let(:fixture){
         File.read("spec/fixtures/v1/get_non_final_cites_certificate.xml")
@@ -61,7 +66,10 @@ RSpec.describe PermitsController, type: :controller do
 
     context "when country adapter supports CITES Toolkit V2" do
       let!(:adapter){
-        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 2)
+        FactoryGirl.create(:adapter, organisation: cites_ma, cites_toolkit_version: 2,
+                             countries_with_access_ids:
+                               [subject.current_user.organisation.country_id]
+                          )
       }
       let(:fixture){
         File.read("spec/fixtures/v2/get_non_final_cites_certificate.xml")
@@ -80,7 +88,10 @@ RSpec.describe PermitsController, type: :controller do
 
     context "when connection times out" do
       let!(:adapter){
-        FactoryGirl.create(:adapter)
+        FactoryGirl.create(:adapter, organisation: cites_ma,
+                           countries_with_access_ids:
+                             [subject.current_user.organisation.country_id]
+                          )
       }
       it "redirects to permits with an error" do
         allow_any_instance_of(Savon::Client).to receive(:call).and_raise(Timeout::Error)
@@ -95,7 +106,10 @@ RSpec.describe PermitsController, type: :controller do
 
     context "when some other error" do
       let!(:adapter){
-        FactoryGirl.create(:adapter)
+        FactoryGirl.create(:adapter, organisation: cites_ma,
+                           countries_with_access_ids:
+                             [subject.current_user.organisation.country_id]
+                          )
       }
       it "redirects to permits with an error" do
         allow_any_instance_of(Savon::Client).to receive(:call).and_raise(StandardError)

--- a/spec/factories/country.rb
+++ b/spec/factories/country.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :country do
-    name 'Italy'
-    iso_code2 'IT'
+    name { Faker::Address.country }
+    iso_code2 { Faker::Address.country_code }
   end
 end

--- a/spec/fixtures/v1/get_non_final_cites_certificate.xml
+++ b/spec/fixtures/v1/get_non_final_cites_certificate.xml
@@ -1,0 +1,800 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v1="urn:CitesDataExchange/v1/" xmlns:urn="urn:un:unece:uncefact:data:draft:CBFShip:1" xmlns:urn1="urn:un:unece:uncefact:data:draft:ReusableAggregateBusinessInformationEntity:1">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <v1:GetNonFinalCitesCertificateResponse>
+         <CBFShip>
+            <urn:SpecifiedExchangedDocumentContext>
+               <!--Zero or more repetitions:-->
+               <urn1:BusinessProcessSpecifiedDocumentContextParameter>
+                  <!--Optional:-->
+                  <urn1:ID>1</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Value>CITES Permitting</urn1:Value>
+                  <!--Optional:-->
+                  <urn1:SpecifiedDocumentVersion>
+                     <!--Optional:-->
+                     <urn1:ID>1</urn1:ID>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime></urn1:IssueDateTime>
+                  </urn1:SpecifiedDocumentVersion>
+               </urn1:BusinessProcessSpecifiedDocumentContextParameter>
+               <!--Zero or more repetitions:-->
+               <urn1:BIMSpecifiedDocumentContextParameter>
+                  <!--Optional:-->
+                  <urn1:ID>09A</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Value></urn1:Value>
+                  <!--Optional:-->
+                  <urn1:SpecifiedDocumentVersion>
+                     <!--Optional:-->
+                     <urn1:ID>1</urn1:ID>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2009-07-14T00:00:00.000+02:00</urn1:IssueDateTime>
+                  </urn1:SpecifiedDocumentVersion>
+               </urn1:BIMSpecifiedDocumentContextParameter>
+            </urn:SpecifiedExchangedDocumentContext>
+            <urn:HeaderExchangedDocument>
+               <!--Optional:-->
+               <urn1:ID>XA000000</urn1:ID>
+               <!--Zero or more repetitions:-->
+               <urn1:Name></urn1:Name>
+               <!--Optional:-->
+               <urn1:TypeCode>R</urn1:TypeCode>
+               <!--Optional:-->
+               <urn1:IssueDateTime>2014-01-06T12:03:52.00+01:00</urn1:IssueDateTime>
+               <!--Optional:-->
+               <urn1:CopyIndicator>false</urn1:CopyIndicator>
+               <!--Optional:-->
+               <urn1:Purpose></urn1:Purpose>
+               <!--Zero or more repetitions:-->
+               <urn1:PurposeCode>T</urn1:PurposeCode>
+               <!--Zero or more repetitions:-->
+               <urn1:Information>For live animals, this permit is only valid if the transportation requirements
+in accordance to the Guidelines for Transport of Live Animals or, in the case of air transport to
+the IATA Live Animals Regulations</urn1:Information>
+               <!--Zero or more repetitions:-->
+               <urn1:ReferenceReferencedDocument>
+                  <!--Optional:-->
+                  <urn1:IssueDateTime></urn1:IssueDateTime>
+                  <!--Optional:-->
+                  <urn1:TypeCode></urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name></urn1:Name>
+                  <!--Optional:-->
+                  <urn1:EffectiveSpecifiedPeriod>
+                     <!--Optional:-->
+                     <urn1:StartDateTime>2014-01-06T12:03:52.000+01:00</urn1:StartDateTime>
+                     <!--Optional:-->
+                     <urn1:EndDateTime>2014-07-05T12:03:52.000+02:00</urn1:EndDateTime>
+                  </urn1:EffectiveSpecifiedPeriod>
+               </urn1:ReferenceReferencedDocument>
+               <!--Optional:-->
+               <urn1:EffectiveSpecifiedPeriod>
+                  <!--Optional:-->
+                  <urn1:StartDateTime>2014-01-06T12:03:52.000+01:00</urn1:StartDateTime>
+                  <!--Optional:-->
+                  <urn1:EndDateTime>2014-07-05T12:03:52.000+02:00</urn1:EndDateTime>
+               </urn1:EffectiveSpecifiedPeriod>
+               <!--Optional:-->
+               <urn1:IssueLogisticsLocation>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name></urn1:Name>
+               </urn1:IssueLogisticsLocation>
+               <!--Optional:-->
+               <urn1:FirstSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>A</urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name>Authority name</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode>00000</urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName>Street</urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName>City</urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryIdentificationTradeCountry>
+                           <!--Zero or more repetitions:-->
+                           <urn1:ID>XA</urn1:ID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name>Neverland</urn1:Name>
+                           <!--Optional:-->
+                           <urn1:SubordinateTradeCountrySubDivision>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                           </urn1:SubordinateTradeCountrySubDivision>
+                        </urn1:CountryIdentificationTradeCountry>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+               </urn1:FirstSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:SecondSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>B</urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryIdentificationTradeCountry>
+                           <!--Zero or more repetitions:-->
+                           <urn1:ID></urn1:ID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                           <!--Optional:-->
+                           <urn1:SubordinateTradeCountrySubDivision>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                           </urn1:SubordinateTradeCountrySubDivision>
+                        </urn1:CountryIdentificationTradeCountry>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+               </urn1:SecondSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:ThirdSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>C</urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryIdentificationTradeCountry>
+                           <!--Zero or more repetitions:-->
+                           <urn1:ID></urn1:ID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                           <!--Optional:-->
+                           <urn1:SubordinateTradeCountrySubDivision>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                           </urn1:SubordinateTradeCountrySubDivision>
+                        </urn1:CountryIdentificationTradeCountry>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+               </urn1:ThirdSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:FourthSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>D</urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryIdentificationTradeCountry>
+                           <!--Zero or more repetitions:-->
+                           <urn1:ID></urn1:ID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                           <!--Optional:-->
+                           <urn1:SubordinateTradeCountrySubDivision>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                           </urn1:SubordinateTradeCountrySubDivision>
+                        </urn1:CountryIdentificationTradeCountry>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+               </urn1:FourthSignatoryDocumentAuthentication>
+            </urn:HeaderExchangedDocument>
+            <urn:SpecifiedSupplyChainConsignment>
+               <!--Optional:-->
+               <urn1:ConsignorTradeParty>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Name>Consignor name</urn1:Name>
+                  <!--Optional:-->
+                  <urn1:PostalTradeAddress>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PostcodeCode>00000</urn1:PostcodeCode>
+                     <!--Optional:-->
+                     <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                     <!--Zero or more repetitions:-->
+                     <urn1:StreetName>Street</urn1:StreetName>
+                     <!--Optional:-->
+                     <urn1:CityName>City</urn1:CityName>
+                     <!--Optional:-->
+                     <urn1:CountryIdentificationTradeCountry>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID>XA</urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name>Neverland</urn1:Name>
+                        <!--Optional:-->
+                        <urn1:SubordinateTradeCountrySubDivision>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SubordinateTradeCountrySubDivision>
+                     </urn1:CountryIdentificationTradeCountry>
+                  </urn1:PostalTradeAddress>
+                  <!--Optional:-->
+                  <urn1:SpecifiedRepresentativePerson>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:SpecifiedRepresentativePerson>
+                  <!--Zero or more repetitions:-->
+                  <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:SpecifiedAuthoritativeSignatoryPerson>
+               </urn1:ConsignorTradeParty>
+               <!--Optional:-->
+               <urn1:ConsigneeTradeParty>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Name>Consignee name</urn1:Name>
+                  <!--Optional:-->
+                  <urn1:PostalTradeAddress>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PostcodeCode>00000</urn1:PostcodeCode>
+                     <!--Optional:-->
+                     <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                     <!--Zero or more repetitions:-->
+                     <urn1:StreetName>Street</urn1:StreetName>
+                     <!--Optional:-->
+                     <urn1:CityName>City</urn1:CityName>
+                     <!--Optional:-->
+                     <urn1:CountryIdentificationTradeCountry>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID>XB</urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name>Wonderland</urn1:Name>
+                        <!--Optional:-->
+                        <urn1:SubordinateTradeCountrySubDivision>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SubordinateTradeCountrySubDivision>
+                     </urn1:CountryIdentificationTradeCountry>
+                  </urn1:PostalTradeAddress>
+                  <!--Optional:-->
+                  <urn1:SpecifiedRepresentativePerson>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:SpecifiedRepresentativePerson>
+                  <!--Zero or more repetitions:-->
+                  <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:SpecifiedAuthoritativeSignatoryPerson>
+               </urn1:ConsigneeTradeParty>
+               <!--Optional:-->
+               <urn1:TransportContractReferencedDocument>
+                  <!--Optional:-->
+                  <urn1:IssueDateTime></urn1:IssueDateTime>
+                  <!--Optional:-->
+                  <urn1:TypeCode></urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name></urn1:Name>
+                  <!--Optional:-->
+                  <urn1:EffectiveSpecifiedPeriod>
+                     <!--Optional:-->
+                     <urn1:StartDateTime></urn1:StartDateTime>
+                     <!--Optional:-->
+                     <urn1:EndDateTime></urn1:EndDateTime>
+                  </urn1:EffectiveSpecifiedPeriod>
+               </urn1:TransportContractReferencedDocument>
+               <!--Zero or more repetitions:-->
+               <urn1:ExaminationTransportEvent>
+                  <!--Optional:-->
+                  <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                  <!--Optional:-->
+                  <urn1:InspectedUnitQuantity unitCode="?"></urn1:InspectedUnitQuantity>
+                  <!--Optional:-->
+                  <urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:OccurrenceLogisticsLocation>
+                  <!--Zero or more repetitions:-->
+                  <urn1:CertifyingTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryIdentificationTradeCountry>
+                           <!--Zero or more repetitions:-->
+                           <urn1:ID></urn1:ID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:Name></urn1:Name>
+                           <!--Optional:-->
+                           <urn1:SubordinateTradeCountrySubDivision>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                           </urn1:SubordinateTradeCountrySubDivision>
+                        </urn1:CountryIdentificationTradeCountry>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:CertifyingTradeParty>
+               </urn1:ExaminationTransportEvent>
+               <!--Zero or more repetitions:-->
+               <urn1:IncludedSupplyChainConsignmentItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID>A</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:OriginTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>XC</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name>Pixieland</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:SubordinateTradeCountrySubDivision>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SubordinateTradeCountrySubDivision>
+                  </urn1:OriginTradeCountry>
+                  <!--Optional:-->
+                  <urn1:ExportTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>XA</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name>Neverland</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:SubordinateTradeCountrySubDivision>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SubordinateTradeCountrySubDivision>
+                  </urn1:ExportTradeCountry>
+                  <!--Zero or more repetitions:-->
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2007-07-09T00:00:00.000+02:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode>861</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>XC12345</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2012-02-23T00:00:00.000+01:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode>811</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>XA12345</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <!--Zero or more repetitions:-->
+                  <urn1:TransportLogisticsPackage>
+                     <!--Optional:-->
+                     <urn1:ItemQuantity unitCode="PCS">5</urn1:ItemQuantity>
+                  </urn1:TransportLogisticsPackage>
+                  <!--Zero or more repetitions:-->
+                  <urn1:IncludedSupplyChainTradeLineItem>
+                     <!--Optional:-->
+                     <urn1:TypeCode>II</urn1:TypeCode>
+                     <!--Optional:-->
+                     <urn1:TypeExtensionCode>W</urn1:TypeExtensionCode>
+                     <!--Optional:-->
+                     <urn1:SpecifiedTradeProduct>
+                        <!--Optional:-->
+                        <urn1:SellerAssignedID></urn1:SellerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Description>watchstraps</urn1:Description>
+                        <!--Zero or more repetitions:-->
+                        <urn1:TypeCode>LPS</urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CommonName>American Alligator</urn1:CommonName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ScientificName>Alligator mississippiensis</urn1:ScientificName>
+                     </urn1:SpecifiedTradeProduct>
+                  </urn1:IncludedSupplyChainTradeLineItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ExaminationTransportEvent>
+                     <!--Optional:-->
+                     <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                     <!--Optional:-->
+                     <urn1:InspectedUnitQuantity unitCode="?"></urn1:InspectedUnitQuantity>
+                     <!--Optional:-->
+                     <urn1:OccurrenceLogisticsLocation>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CertifyingTradeParty>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:PostalTradeAddress>
+                           <!--Zero or more repetitions:-->
+                           <urn1:PostcodeCode></urn1:PostcodeCode>
+                           <!--Optional:-->
+                           <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                           <!--Zero or more repetitions:-->
+                           <urn1:StreetName></urn1:StreetName>
+                           <!--Optional:-->
+                           <urn1:CityName></urn1:CityName>
+                           <!--Optional:-->
+                           <urn1:CountryIdentificationTradeCountry>
+                              <!--Zero or more repetitions:-->
+                              <urn1:ID></urn1:ID>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                              <!--Optional:-->
+                              <urn1:SubordinateTradeCountrySubDivision>
+                                 <!--Zero or more repetitions:-->
+                                 <urn1:Name></urn1:Name>
+                              </urn1:SubordinateTradeCountrySubDivision>
+                           </urn1:CountryIdentificationTradeCountry>
+                        </urn1:PostalTradeAddress>
+                        <!--Optional:-->
+                        <urn1:SpecifiedRepresentativePerson>
+                           <!--Optional:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SpecifiedRepresentativePerson>
+                        <!--Zero or more repetitions:-->
+                        <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                           <!--Optional:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     </urn1:CertifyingTradeParty>
+                  </urn1:ExaminationTransportEvent>
+                  <!--Optional:-->
+                  <urn1:ApplicableCrossBorderGovernmentProcedure>
+                     <!--Optional:-->
+                     <urn1:UsedToDateQuotaQuantity unitCode="?"></urn1:UsedToDateQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AnnualQuotaQuantity unitCode="?"></urn1:AnnualQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AcquisitionDateTime></urn1:AcquisitionDateTime>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PreviousReferencedDocument>
+                        <!--Optional:-->
+                        <urn1:IssueDateTime></urn1:IssueDateTime>
+                        <!--Optional:-->
+                        <urn1:TypeCode></urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:EffectiveSpecifiedPeriod>
+                           <!--Optional:-->
+                           <urn1:StartDateTime></urn1:StartDateTime>
+                           <!--Optional:-->
+                           <urn1:EndDateTime></urn1:EndDateTime>
+                        </urn1:EffectiveSpecifiedPeriod>
+                     </urn1:PreviousReferencedDocument>
+                  </urn1:ApplicableCrossBorderGovernmentProcedure>
+               </urn1:IncludedSupplyChainConsignmentItem>
+
+               <urn1:IncludedSupplyChainConsignmentItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID>B</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:OriginTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>TH</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name>Thailand</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:SubordinateTradeCountrySubDivision>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SubordinateTradeCountrySubDivision>
+                  </urn1:OriginTradeCountry>
+                  <!--Optional:-->
+                  <urn1:ExportTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>FR</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name>France</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:SubordinateTradeCountrySubDivision>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:SubordinateTradeCountrySubDivision>
+                  </urn1:ExportTradeCountry>
+                  <!--Zero or more repetitions:-->
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2007-07-09T00:00:00.000+02:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode>861</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                     <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2012-02-23T00:00:00.000+01:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode>811</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID>FR1202501030-R</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <!--Zero or more repetitions:-->
+                  <urn1:TransportLogisticsPackage>
+                     <!--Optional:-->
+                     <urn1:ItemQuantity unitCode="PCS">10</urn1:ItemQuantity>
+                  </urn1:TransportLogisticsPackage>
+                  <!--Zero or more repetitions:-->
+                  <urn1:IncludedSupplyChainTradeLineItem>
+                     <!--Optional:-->
+                     <urn1:TypeCode>I</urn1:TypeCode>
+                     <!--Optional:-->
+                     <urn1:TypeExtensionCode>D</urn1:TypeExtensionCode>
+                     <!--Optional:-->
+                     <urn1:SpecifiedTradeProduct>
+                        <!--Optional:-->
+                        <urn1:SellerAssignedID></urn1:SellerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Description>watchstraps</urn1:Description>
+                        <!--Zero or more repetitions:-->
+                        <urn1:TypeCode>LPS</urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CommonName>Siamese Crocodile</urn1:CommonName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ScientificName>Crocodylus siamensis</urn1:ScientificName>
+                     </urn1:SpecifiedTradeProduct>
+                  </urn1:IncludedSupplyChainTradeLineItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ExaminationTransportEvent>
+                     <!--Optional:-->
+                     <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                     <!--Optional:-->
+                     <urn1:InspectedUnitQuantity unitCode="?"></urn1:InspectedUnitQuantity>
+                     <!--Optional:-->
+                     <urn1:OccurrenceLogisticsLocation>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                     </urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CertifyingTradeParty>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Optional:-->
+                        <urn1:Name></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:PostalTradeAddress>
+                           <!--Zero or more repetitions:-->
+                           <urn1:PostcodeCode></urn1:PostcodeCode>
+                           <!--Optional:-->
+                           <urn1:PostOfficeBox></urn1:PostOfficeBox>
+                           <!--Zero or more repetitions:-->
+                           <urn1:StreetName></urn1:StreetName>
+                           <!--Optional:-->
+                           <urn1:CityName></urn1:CityName>
+                           <!--Optional:-->
+                           <urn1:CountryIdentificationTradeCountry>
+                              <!--Zero or more repetitions:-->
+                              <urn1:ID></urn1:ID>
+                              <!--Zero or more repetitions:-->
+                              <urn1:Name></urn1:Name>
+                              <!--Optional:-->
+                              <urn1:SubordinateTradeCountrySubDivision>
+                                 <!--Zero or more repetitions:-->
+                                 <urn1:Name></urn1:Name>
+                              </urn1:SubordinateTradeCountrySubDivision>
+                           </urn1:CountryIdentificationTradeCountry>
+                        </urn1:PostalTradeAddress>
+                        <!--Optional:-->
+                        <urn1:SpecifiedRepresentativePerson>
+                           <!--Optional:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SpecifiedRepresentativePerson>
+                        <!--Zero or more repetitions:-->
+                        <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                           <!--Optional:-->
+                           <urn1:Name></urn1:Name>
+                        </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     </urn1:CertifyingTradeParty>
+                  </urn1:ExaminationTransportEvent>
+                  <!--Optional:-->
+                  <urn1:ApplicableCrossBorderGovernmentProcedure>
+                     <!--Optional:-->
+                     <urn1:UsedToDateQuotaQuantity unitCode="?"></urn1:UsedToDateQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AnnualQuotaQuantity unitCode="?"></urn1:AnnualQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AcquisitionDateTime></urn1:AcquisitionDateTime>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PreviousReferencedDocument>
+                        <!--Optional:-->
+                        <urn1:IssueDateTime></urn1:IssueDateTime>
+                        <!--Optional:-->
+                        <urn1:TypeCode></urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:EffectiveSpecifiedPeriod>
+                           <!--Optional:-->
+                           <urn1:StartDateTime></urn1:StartDateTime>
+                           <!--Optional:-->
+                           <urn1:EndDateTime></urn1:EndDateTime>
+                        </urn1:EffectiveSpecifiedPeriod>
+                     </urn1:PreviousReferencedDocument>
+                  </urn1:ApplicableCrossBorderGovernmentProcedure>
+               </urn1:IncludedSupplyChainConsignmentItem>
+               
+               <!--Optional:-->
+               <urn1:ImportTradeCountry>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name></urn1:Name>
+                  <!--Optional:-->
+                  <urn1:SubordinateTradeCountrySubDivision>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name></urn1:Name>
+                  </urn1:SubordinateTradeCountrySubDivision>
+               </urn1:ImportTradeCountry>
+            </urn:SpecifiedSupplyChainConsignment>
+         </CBFShip>
+         <!--Zero or more repetitions:-->
+         <Attachments>
+            <AttachmentName>Test.pdf</AttachmentName>
+            <AttachmentContent>cid:451619371907</AttachmentContent>
+         </Attachments>
+         <Composite>false</Composite>
+      </v1:GetNonFinalCitesCertificateResponse>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/fixtures/v2/get_non_final_cites_certificate.xml
+++ b/spec/fixtures/v2/get_non_final_cites_certificate.xml
@@ -1,0 +1,769 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v2="urn:CitesDataExchange/v2/" xmlns:urn="urn:un:unece:uncefact:data:standard:CITESEPermit:2" xmlns:urn1="urn:un:unece:uncefact:data:draft:ReusableAggregateBusinessInformationEntity:1">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <v2:GetNonFinalCitesCertificateResponse>
+         <CITESEPermit>
+            <urn:SpecifiedExchangedDocumentContext>
+               <!--Zero or more repetitions:-->
+               <urn1:BusinessProcessSpecifiedDocumentContextParameter>
+                  <!--Optional:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?">1</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Value languageID="EN">CITES Permitting</urn1:Value>
+                  <!--Optional:-->
+                  <urn1:SpecifiedDocumentVersion>
+                     <!--Optional:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">1</urn1:ID>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime></urn1:IssueDateTime>
+                  </urn1:SpecifiedDocumentVersion>
+               </urn1:BusinessProcessSpecifiedDocumentContextParameter>
+               <!--Zero or more repetitions:-->
+               <urn1:BIMSpecifiedDocumentContextParameter>
+                  <!--Optional:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?">09A</urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Value languageID="EN"></urn1:Value>
+                  <!--Optional:-->
+                  <urn1:SpecifiedDocumentVersion>
+                     <!--Optional:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">1</urn1:ID>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2009-07-14T00:00:00.000+02:00</urn1:IssueDateTime>
+                  </urn1:SpecifiedDocumentVersion>
+               </urn1:BIMSpecifiedDocumentContextParameter>
+            </urn:SpecifiedExchangedDocumentContext>
+            <urn:HeaderExchangedDocument>
+               <!--Optional:-->
+               <urn1:ID schemeID="?" schemeAgencyID="?">XA000000</urn1:ID>
+               <!--Zero or more repetitions:-->
+               <urn1:Name languageID="EN"></urn1:Name>
+               <!--Optional:-->
+               <urn1:TypeCode listID="1001" listAgencyID="6">R</urn1:TypeCode>
+               <!--Optional:-->
+               <urn1:IssueDateTime>2014-01-06T12:03:52.00+01:00</urn1:IssueDateTime>
+               <!--Optional:-->
+               <urn1:CopyIndicator>false</urn1:CopyIndicator>
+               <!--Optional:-->
+               <urn1:Purpose languageID="EN"></urn1:Purpose>
+               <!--Zero or more repetitions:-->
+               <urn1:PurposeCode>T</urn1:PurposeCode>
+               <!--Zero or more repetitions:-->
+               <urn1:Information languageID="EN">For live animals, this permit is only valid if the transportation requirements
+in accordance to the Guidelines for Transport of Live Animals or, in the case of air transport to
+the IATA Live Animals Regulations</urn1:Information>
+               <!--Zero or more repetitions:-->
+               <urn1:ReferenceReferencedDocument>
+                  <!--Optional:-->
+                  <urn1:IssueDateTime></urn1:IssueDateTime>
+                  <!--Optional:-->
+                  <urn1:TypeCode listID="1001" listAgencyID="6"></urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name languageID="EN"></urn1:Name>
+                  <!--Optional:-->
+                  <urn1:EffectiveSpecifiedPeriod>
+                     <!--Optional:-->
+                     <urn1:StartDateTime>2014-01-06T12:03:52.000+01:00</urn1:StartDateTime>
+                     <!--Optional:-->
+                     <urn1:EndDateTime>2014-07-05T12:03:52.000+02:00</urn1:EndDateTime>
+                  </urn1:EffectiveSpecifiedPeriod>
+               </urn1:ReferenceReferencedDocument>
+               <!--Optional:-->
+               <urn1:EffectiveSpecifiedPeriod>
+                  <!--Optional:-->
+                  <urn1:StartDateTime>2014-01-06T12:03:52.000+01:00</urn1:StartDateTime>
+                  <!--Optional:-->
+                  <urn1:EndDateTime>2014-07-05T12:03:52.000+02:00</urn1:EndDateTime>
+               </urn1:EffectiveSpecifiedPeriod>
+               <!--Optional:-->
+               <urn1:IssueLogisticsLocation>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name languageID="EN"></urn1:Name>
+               </urn1:IssueLogisticsLocation>
+               <!--Optional:-->
+               <urn1:FirstSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>A</urn1:TypeCode>
+                  <!--Optional:-->
+                  <urn1:ActualDateTime></urn1:ActualDateTime>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement languageID="EN"></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN">Authority name</urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode listID="?" listAgencyID="?">00000</urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName languageID="EN">Street</urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName languageID="EN">City</urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryID schemeID="?" schemeAgencyID="?">XA</urn1:CountryID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountryName languageID="EN">Neverland</urn1:CountryName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+                  <!--Optional:-->
+                  <urn1:IssueLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:IssueLogisticsLocation>
+               </urn1:FirstSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:SecondSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>B</urn1:TypeCode>
+                  <!--Optional:-->
+                  <urn1:ActualDateTime></urn1:ActualDateTime>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement languageID="EN"></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName languageID="EN"></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName languageID="EN"></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountryName languageID="EN"></urn1:CountryName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+                  <!--Optional:-->
+                  <urn1:IssueLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:IssueLogisticsLocation>
+               </urn1:SecondSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:ThirdSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>C</urn1:TypeCode>
+                  <!--Optional:-->
+                  <urn1:ActualDateTime></urn1:ActualDateTime>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement languageID="EN"></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName languageID="EN"></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName languageID="EN"></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountryName languageID="EN"></urn1:CountryName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+                  <!--Optional:-->
+                  <urn1:IssueLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:IssueLogisticsLocation>
+               </urn1:ThirdSignatoryDocumentAuthentication>
+               <!--Optional:-->
+               <urn1:FourthSignatoryDocumentAuthentication>
+                  <!--Optional:-->
+                  <urn1:TypeCode>D</urn1:TypeCode>
+                  <!--Optional:-->
+                  <urn1:ActualDateTime></urn1:ActualDateTime>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Statement languageID="EN"></urn1:Statement>
+                  <!--Optional:-->
+                  <urn1:ProviderTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName languageID="EN"></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName languageID="EN"></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountryName languageID="EN"></urn1:CountryName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:ProviderTradeParty>
+                  <!--Optional:-->
+                  <urn1:IssueLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:IssueLogisticsLocation>
+               </urn1:FourthSignatoryDocumentAuthentication>
+            </urn:HeaderExchangedDocument>
+            <urn:SpecifiedSupplyChainConsignment>
+               <!--Optional:-->
+               <urn1:ConsignorTradeParty>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Name languageID="EN">Consignor name</urn1:Name>
+                  <!--Optional:-->
+                  <urn1:PostalTradeAddress>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PostcodeCode listID="?" listAgencyID="?">00000</urn1:PostcodeCode>
+                     <!--Optional:-->
+                     <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                     <!--Zero or more repetitions:-->
+                     <urn1:StreetName languageID="EN">Street</urn1:StreetName>
+                     <!--Optional:-->
+                     <urn1:CityName languageID="EN">City</urn1:CityName>
+                     <!--Optional:-->
+                     <urn1:CountryID schemeID="?" schemeAgencyID="?">XA</urn1:CountryID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CountryName languageID="EN">Neverland</urn1:CountryName>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                  </urn1:PostalTradeAddress>
+                  <!--Optional:-->
+                  <urn1:SpecifiedRepresentativePerson>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:SpecifiedRepresentativePerson>
+                  <!--Zero or more repetitions:-->
+                  <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:SpecifiedAuthoritativeSignatoryPerson>
+               </urn1:ConsignorTradeParty>
+               <!--Optional:-->
+               <urn1:ConsigneeTradeParty>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Optional:-->
+                  <urn1:Name languageID="EN">Consignee name</urn1:Name>
+                  <!--Optional:-->
+                  <urn1:PostalTradeAddress>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PostcodeCode listID="?" listAgencyID="?">00000</urn1:PostcodeCode>
+                     <!--Optional:-->
+                     <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                     <!--Zero or more repetitions:-->
+                     <urn1:StreetName languageID="EN">Street</urn1:StreetName>
+                     <!--Optional:-->
+                     <urn1:CityName languageID="EN">City</urn1:CityName>
+                     <!--Optional:-->
+                     <urn1:CountryID schemeID="?" schemeAgencyID="?">XB</urn1:CountryID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CountryName languageID="EN">Wonderland</urn1:CountryName>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                  </urn1:PostalTradeAddress>
+                  <!--Optional:-->
+                  <urn1:SpecifiedRepresentativePerson>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:SpecifiedRepresentativePerson>
+                  <!--Zero or more repetitions:-->
+                  <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:SpecifiedAuthoritativeSignatoryPerson>
+               </urn1:ConsigneeTradeParty>
+               <!--Optional:-->
+               <urn1:TransportContractReferencedDocument>
+                  <!--Optional:-->
+                  <urn1:IssueDateTime></urn1:IssueDateTime>
+                  <!--Optional:-->
+                  <urn1:TypeCode listID="1001" listAgencyID="6"></urn1:TypeCode>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:Name languageID="EN"></urn1:Name>
+                  <!--Optional:-->
+                  <urn1:EffectiveSpecifiedPeriod>
+                     <!--Optional:-->
+                     <urn1:StartDateTime></urn1:StartDateTime>
+                     <!--Optional:-->
+                     <urn1:EndDateTime></urn1:EndDateTime>
+                  </urn1:EffectiveSpecifiedPeriod>
+               </urn1:TransportContractReferencedDocument>
+               <!--Zero or more repetitions:-->
+               <urn1:ExaminationTransportEvent>
+                  <!--Optional:-->
+                  <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                  <!--Optional:-->
+                  <urn1:UnitQuantity unitCode="?"></urn1:UnitQuantity>
+                  <!--Optional:-->
+                  <urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                  </urn1:OccurrenceLogisticsLocation>
+                  <!--Zero or more repetitions:-->
+                  <urn1:CertifyingTradeParty>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Optional:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:PostalTradeAddress>
+                        <!--Zero or more repetitions:-->
+                        <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                        <!--Optional:-->
+                        <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                        <!--Zero or more repetitions:-->
+                        <urn1:StreetName languageID="EN"></urn1:StreetName>
+                        <!--Optional:-->
+                        <urn1:CityName languageID="EN"></urn1:CityName>
+                        <!--Optional:-->
+                        <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountryName languageID="EN"></urn1:CountryName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                     </urn1:PostalTradeAddress>
+                     <!--Optional:-->
+                     <urn1:SpecifiedRepresentativePerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedRepresentativePerson>
+                     <!--Zero or more repetitions:-->
+                     <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                  </urn1:CertifyingTradeParty>
+               </urn1:ExaminationTransportEvent>
+               <!--Zero or more repetitions:-->
+               <urn1:IncludedSupplyChainConsignmentItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?">A</urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:PhysicalLogisticsShippingMarks>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Marking languageID="EN">XXX</urn1:Marking>
+                  </urn1:PhysicalLogisticsShippingMarks>
+                  <!--Optional:-->
+                  <urn1:OriginTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">XC</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN">Pixieland</urn1:Name>
+                  </urn1:OriginTradeCountry>
+                  <!--Optional:-->
+                  <urn1:ExportTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">XA</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN">Neverland</urn1:Name>
+                  </urn1:ExportTradeCountry>
+                  <!--Zero or more repetitions:-->
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2007-07-09T00:00:00.000+02:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode listID="1001" listAgencyID="6">861</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">XC12345</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2012-02-23T00:00:00.000+01:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode listID="1001" listAgencyID="6">811</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">XA12345</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <!--Zero or more repetitions:-->
+                  <urn1:TransportLogisticsPackage>
+                     <!--Optional:-->
+                     <urn1:ItemQuantity unitCode="PCS">5</urn1:ItemQuantity>
+                  </urn1:TransportLogisticsPackage>
+                  <!--Zero or more repetitions:-->
+                  <urn1:IncludedSupplyChainTradeLineItem>
+                     <!--Optional:-->
+                     <urn1:TypeCode>II</urn1:TypeCode>
+                     <!--Optional:-->
+                     <urn1:TypeExtensionCode>W</urn1:TypeExtensionCode>
+                     <!--Optional:-->
+                     <urn1:SpecifiedTradeProduct>
+                        <!--Optional:-->
+                        <urn1:SellerAssignedID schemeID="?" schemeAgencyID="?"></urn1:SellerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ManufacturerAssignedID schemeID="?" schemeAgencyID="?"></urn1:ManufacturerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Description languageID="EN">watchstraps</urn1:Description>
+                        <!--Zero or more repetitions:-->
+                        <urn1:TypeCode listID="?" listAgencyID="?">LPS</urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CommonName languageID="EN">American Alligator</urn1:CommonName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ScientificName languageID="EN">Alligator mississippiensis</urn1:ScientificName>
+                     </urn1:SpecifiedTradeProduct>
+                  </urn1:IncludedSupplyChainTradeLineItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ExaminationTransportEvent>
+                     <!--Optional:-->
+                     <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                     <!--Optional:-->
+                     <urn1:UnitQuantity unitCode="?"></urn1:UnitQuantity>
+                     <!--Optional:-->
+                     <urn1:OccurrenceLogisticsLocation>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CertifyingTradeParty>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:PostalTradeAddress>
+                           <!--Zero or more repetitions:-->
+                           <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                           <!--Optional:-->
+                           <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                           <!--Zero or more repetitions:-->
+                           <urn1:StreetName languageID="EN"></urn1:StreetName>
+                           <!--Optional:-->
+                           <urn1:CityName languageID="EN"></urn1:CityName>
+                           <!--Optional:-->
+                           <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:CountryName languageID="EN"></urn1:CountryName>
+                           <!--Zero or more repetitions:-->
+                           <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                        </urn1:PostalTradeAddress>
+                        <!--Optional:-->
+                        <urn1:SpecifiedRepresentativePerson>
+                           <!--Optional:-->
+                           <urn1:Name languageID="EN"></urn1:Name>
+                        </urn1:SpecifiedRepresentativePerson>
+                        <!--Zero or more repetitions:-->
+                        <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                           <!--Optional:-->
+                           <urn1:Name languageID="EN"></urn1:Name>
+                        </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     </urn1:CertifyingTradeParty>
+                  </urn1:ExaminationTransportEvent>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ApplicableCrossBorderRegulatoryProcedure>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CategoryCode listID="?" listAgencyID="?"></urn1:CategoryCode>
+                     <!--Optional:-->
+                     <urn1:UsedToDateQuotaQuantity unitCode="?"></urn1:UsedToDateQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AnnualQuotaQuantity unitCode="?"></urn1:AnnualQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AcquisitionDateTime></urn1:AcquisitionDateTime>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PreviousReferencedDocument>
+                        <!--Optional:-->
+                        <urn1:IssueDateTime></urn1:IssueDateTime>
+                        <!--Optional:-->
+                        <urn1:TypeCode listID="1001" listAgencyID="6"></urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:EffectiveSpecifiedPeriod>
+                           <!--Optional:-->
+                           <urn1:StartDateTime></urn1:StartDateTime>
+                           <!--Optional:-->
+                           <urn1:EndDateTime></urn1:EndDateTime>
+                        </urn1:EffectiveSpecifiedPeriod>
+                     </urn1:PreviousReferencedDocument>
+                  </urn1:ApplicableCrossBorderRegulatoryProcedure>
+               </urn1:IncludedSupplyChainConsignmentItem>
+
+               <urn1:IncludedSupplyChainConsignmentItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ID schemeID="?" schemeAgencyID="?">B</urn1:ID>
+                  <!--Zero or more repetitions:-->
+                  <urn1:PhysicalLogisticsShippingMarks>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Marking languageID="EN">XXX</urn1:Marking>
+                  </urn1:PhysicalLogisticsShippingMarks>
+                  <!--Optional:-->
+                  <urn1:OriginTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">TH</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN">Thailand</urn1:Name>
+                  </urn1:OriginTradeCountry>
+                  <!--Optional:-->
+                  <urn1:ExportTradeCountry>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">FR</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN">France</urn1:Name>
+                  </urn1:ExportTradeCountry>
+                  <!--Zero or more repetitions:-->
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2007-07-09T00:00:00.000+02:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode listID="1001" listAgencyID="6">861</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <urn1:AssociatedReferencedDocument>
+                     <!--Optional:-->
+                     <urn1:IssueDateTime>2012-02-23T00:00:00.000+01:00</urn1:IssueDateTime>
+                     <!--Optional:-->
+                     <urn1:TypeCode listID="1001" listAgencyID="6">811</urn1:TypeCode>
+                     <!--Zero or more repetitions:-->
+                     <urn1:ID schemeID="?" schemeAgencyID="?">FR1202501030-R</urn1:ID>
+                     <!--Zero or more repetitions:-->
+                     <urn1:Name languageID="EN"></urn1:Name>
+                     <!--Optional:-->
+                     <urn1:EffectiveSpecifiedPeriod>
+                        <!--Optional:-->
+                        <urn1:StartDateTime></urn1:StartDateTime>
+                        <!--Optional:-->
+                        <urn1:EndDateTime></urn1:EndDateTime>
+                     </urn1:EffectiveSpecifiedPeriod>
+                  </urn1:AssociatedReferencedDocument>
+                  <!--Zero or more repetitions:-->
+                  <urn1:TransportLogisticsPackage>
+                     <!--Optional:-->
+                     <urn1:ItemQuantity unitCode="PCS">10</urn1:ItemQuantity>
+                  </urn1:TransportLogisticsPackage>
+                  <!--Zero or more repetitions:-->
+                  <urn1:IncludedSupplyChainTradeLineItem>
+                     <!--Optional:-->
+                     <urn1:TypeCode>I</urn1:TypeCode>
+                     <!--Optional:-->
+                     <urn1:TypeExtensionCode>D</urn1:TypeExtensionCode>
+                     <!--Optional:-->
+                     <urn1:SpecifiedTradeProduct>
+                        <!--Optional:-->
+                        <urn1:SellerAssignedID schemeID="?" schemeAgencyID="?"></urn1:SellerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ManufacturerAssignedID schemeID="?" schemeAgencyID="?"></urn1:ManufacturerAssignedID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Description languageID="EN">watchstraps</urn1:Description>
+                        <!--Zero or more repetitions:-->
+                        <urn1:TypeCode listID="?" listAgencyID="?">LPS</urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:CommonName languageID="EN">Siamese Crocodile</urn1:CommonName>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ScientificName languageID="EN">Crocodylus siamensis</urn1:ScientificName>
+                     </urn1:SpecifiedTradeProduct>
+                  </urn1:IncludedSupplyChainTradeLineItem>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ExaminationTransportEvent>
+                     <!--Optional:-->
+                     <urn1:ActualOccurrenceDateTime></urn1:ActualOccurrenceDateTime>
+                     <!--Optional:-->
+                     <urn1:UnitQuantity unitCode="?"></urn1:UnitQuantity>
+                     <!--Optional:-->
+                     <urn1:OccurrenceLogisticsLocation>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                     </urn1:OccurrenceLogisticsLocation>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CertifyingTradeParty>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Optional:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:PostalTradeAddress>
+                           <!--Zero or more repetitions:-->
+                           <urn1:PostcodeCode listID="?" listAgencyID="?"></urn1:PostcodeCode>
+                           <!--Optional:-->
+                           <urn1:PostOfficeBox languageID="EN"></urn1:PostOfficeBox>
+                           <!--Zero or more repetitions:-->
+                           <urn1:StreetName languageID="EN"></urn1:StreetName>
+                           <!--Optional:-->
+                           <urn1:CityName languageID="EN"></urn1:CityName>
+                           <!--Optional:-->
+                           <urn1:CountryID schemeID="?" schemeAgencyID="?"></urn1:CountryID>
+                           <!--Zero or more repetitions:-->
+                           <urn1:CountryName languageID="EN"></urn1:CountryName>
+                           <!--Zero or more repetitions:-->
+                           <urn1:CountrySubDivisionName languageID="EN"></urn1:CountrySubDivisionName>
+                        </urn1:PostalTradeAddress>
+                        <!--Optional:-->
+                        <urn1:SpecifiedRepresentativePerson>
+                           <!--Optional:-->
+                           <urn1:Name languageID="EN"></urn1:Name>
+                        </urn1:SpecifiedRepresentativePerson>
+                        <!--Zero or more repetitions:-->
+                        <urn1:SpecifiedAuthoritativeSignatoryPerson>
+                           <!--Optional:-->
+                           <urn1:Name languageID="EN"></urn1:Name>
+                        </urn1:SpecifiedAuthoritativeSignatoryPerson>
+                     </urn1:CertifyingTradeParty>
+                  </urn1:ExaminationTransportEvent>
+                  <!--Zero or more repetitions:-->
+                  <urn1:ApplicableCrossBorderRegulatoryProcedure>
+                     <!--Zero or more repetitions:-->
+                     <urn1:CategoryCode listID="?" listAgencyID="?"></urn1:CategoryCode>
+                     <!--Optional:-->
+                     <urn1:UsedToDateQuotaQuantity unitCode="?"></urn1:UsedToDateQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AnnualQuotaQuantity unitCode="?"></urn1:AnnualQuotaQuantity>
+                     <!--Optional:-->
+                     <urn1:AcquisitionDateTime></urn1:AcquisitionDateTime>
+                     <!--Zero or more repetitions:-->
+                     <urn1:PreviousReferencedDocument>
+                        <!--Optional:-->
+                        <urn1:IssueDateTime></urn1:IssueDateTime>
+                        <!--Optional:-->
+                        <urn1:TypeCode listID="1001" listAgencyID="6"></urn1:TypeCode>
+                        <!--Zero or more repetitions:-->
+                        <urn1:ID schemeID="?" schemeAgencyID="?"></urn1:ID>
+                        <!--Zero or more repetitions:-->
+                        <urn1:Name languageID="EN"></urn1:Name>
+                        <!--Optional:-->
+                        <urn1:EffectiveSpecifiedPeriod>
+                           <!--Optional:-->
+                           <urn1:StartDateTime></urn1:StartDateTime>
+                           <!--Optional:-->
+                           <urn1:EndDateTime></urn1:EndDateTime>
+                        </urn1:EffectiveSpecifiedPeriod>
+                     </urn1:PreviousReferencedDocument>
+                  </urn1:ApplicableCrossBorderRegulatoryProcedure>
+               </urn1:IncludedSupplyChainConsignmentItem>
+
+            
+            </urn:SpecifiedSupplyChainConsignment>
+         </CITESEPermit>
+         <!--Zero or more repetitions:-->
+         <Attachments>
+            <AttachmentName></AttachmentName>
+            <AttachmentContent>cid:311886019166</AttachmentContent>
+         </Attachments>
+         <Composite>false</Composite>
+      </v2:GetNonFinalCitesCertificateResponse>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "date_format" do
+    it "parses datetime string and returns date string" do
+      expect(helper.date_format('2012-02-23T00:00:00.000+01:00')).to eql('23-02-2012')
+    end
+
+    it "returns argument if it is not a date" do
+      expect(helper.date_format('last week')).to eql('last week')
+    end
+  end
+end


### PR DESCRIPTION
Adds support for CITES Toolkit V2 permits. Still keeping V1 in, although I expect we will drop it eventually.

The supported version of the toolkit is an attribute of the adapter. At the moment we have 2 dummy web services set up supporting the 2 versions (same data returned, but formatted differently according to version.)
