### PR TITLE
Same country access

### DIFF
--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -62,7 +62,7 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     if !organisation.present?
       render_soap_error "AdapterNotFound"
     elsif !organisation.adapter.has_country?(user.organisation.country_id) &&
-      !user.is_system_managers?
+      !user.can_access_adapter?(organisation.country_id)
       render_soap_error "AdapterNotAvailable"
     else
       @adapter = organisation.adapter

--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -50,8 +50,8 @@ class PermitsController < ApplicationController
       redirect_to(permits_path) && return
     end
     user_country = current_user.organisation.country_id
-    if !organisation.adapter.has_country?(user_country) &&
-      !current_user.is_system_managers?
+    unless organisation.adapter.has_country?(user_country) ||
+      current_user.can_access_adapter?(organisation.country_id)
       flash.alert = 'Web Service access denied'
       redirect_to(permits_path) && return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,10 @@ class User < ApplicationRecord
     UserMailer.welcome_email(self).deliver_now
   end
 
+  def can_access_adapter?(country_id)
+    self.is_system_managers? || self.organisation.country_id == country_id
+  end
+
   Organisation::VALID_ROLES.each do |role|
     role_formatted = role.downcase.tr(" ", "_")
     define_method("is_#{role_formatted}?") do

--- a/spec/controllers/permits_controller_spec.rb
+++ b/spec/controllers/permits_controller_spec.rb
@@ -165,6 +165,21 @@ RSpec.describe PermitsController, type: :controller do
           expect(response.status).to eq(200)
         end
       end
+
+      context "when user is from same country as adapter" do
+        it "has a 200 status code" do
+          user_org = subject.current_user.organisation
+          adapter_org = adapter.organisation
+          user_org.update_attributes(country_id: adapter_org.country_id)
+          expect(Adapters::SimpleAdapter).to receive(:run).and_return(savon_response)
+          expect(savon_response).to receive(:to_xml).and_return(fixture)
+          get :show, params: {
+            country: cites_ma.country.iso_code2,
+            permit_identifier: '123'
+          }
+          expect(response.status).to eq(200)
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Allows user with same country as the adapter to access it without any special permission
