### PR TITLE
Google analytics tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem 'httparty'
 
 gem 'select2-rails'
 
+# GA Tracking
+gem 'staccato-rails'
+
 group :development do
   # Docs
   gem 'yard', '~> 0.8.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
     sshkit (1.11.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    staccato (0.5.0)
+    staccato-rails (0.0.1)
+      staccato (>= 0.0.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -299,6 +302,7 @@ DEPENDENCIES
   savon
   select2-rails
   simplecov
+  staccato-rails
   turbolinks
   uglifier (>= 1.3.0)
   wash_out

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::BaseController < ApplicationController
   private
 
   def soap_adapter_exception(e)
+    track_soap_response(e)
     if e.cause.is_a?(Timeout::Error)
       render_soap_error 'This request took too long to process...'
     elsif e.cause.is_a?(Savon::SOAPFault)
@@ -12,5 +13,4 @@ class Api::V1::BaseController < ApplicationController
       render_soap_error 'Something went wrong'
     end
   end
-
 end

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -73,7 +73,6 @@ class Api::V1::SoapApiController < Api::V1::BaseController
   end
 
   def track_soap_request
-    #to get the action just use `action_name`
     @hit = Staccato::Pageview.new(tracker, path: request.path)
     GaTracker.add_caller_identification(@hit, request, @user)
     GaTracker.add_request_meta_data(@hit, request, action_name, params, @adapter)

--- a/app/controllers/api/v1/soap_api_controller.rb
+++ b/app/controllers/api/v1/soap_api_controller.rb
@@ -6,6 +6,9 @@ class Api::V1::SoapApiController < Api::V1::BaseController
   }
 
   before_action :load_adapter, except: :_generate_wsdl
+  before_action :track_soap_request, except: :_generate_wsdl
+
+  after_action :track_soap_response, except: :_generate_wsdl
 
   soap_action :get_final_cites_certificate,
               args: {
@@ -58,15 +61,30 @@ class Api::V1::SoapApiController < Api::V1::BaseController
     organisation = Organisation.cites_mas.with_available_adapters.
       joins(:country).where('countries.iso_code2' => params[:IsoCountryCode]).
       first
-    user = get_user
+    @user = get_user
     if !organisation.present?
       render_soap_error "AdapterNotFound"
-    elsif !organisation.adapter.has_country?(user.organisation.country_id) &&
-      !user.can_access_adapter?(organisation.country_id)
+    elsif !organisation.adapter.has_country?(@user.organisation.country_id) &&
+      !@user.can_access_adapter?(organisation.country_id)
       render_soap_error "AdapterNotAvailable"
     else
       @adapter = organisation.adapter
     end
+  end
+
+  def track_soap_request
+    #to get the action just use `action_name`
+    @hit = Staccato::Pageview.new(tracker, path: request.path)
+    GaTracker.add_caller_identification(@hit, request, @user)
+    GaTracker.add_request_meta_data(@hit, request, action_name, params, @adapter)
+    @start_time = Time.now
+  end
+
+  def track_soap_response(exception=nil)
+    response_time = (Time.now - @start_time).to_f
+    GaTracker.add_response_meta_data(@hit, response, response_time, exception)
+    GaTracker.add_metrics(@hit)
+    @hit.track!
   end
 
   def get_user

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -95,4 +95,8 @@ Rails.application.configure do
 
   config.wash_out.camelize_wsdl = true
   config.wash_out.parser = :nokogiri
+
+  #GA Tracking
+  config.staccato.tracker_id = Rails.application.secrets.ga_tracking_id
+  config.staccato.hostname = 'epix-staging.linode.unep-wcmc.org'
 end

--- a/lib/modules/ga_tracker.rb
+++ b/lib/modules/ga_tracker.rb
@@ -38,7 +38,7 @@ module GaTracker
     hit.add_custom_dimension(DIMENSIONS[:response_status], response.status)
     failure_details = exception.present? ? exception.message : ' '
     hit.add_custom_dimension(DIMENSIONS[:failure_details], failure_details)
-    timeout = exception.present? ? exception.cause.is_a?(Tiemout::Error) : false
+    timeout = exception.present? ? exception.cause.is_a?(Timeout::Error) : false
     hit.add_custom_dimension(DIMENSIONS[:timeout], timeout)
   end
 

--- a/lib/modules/ga_tracker.rb
+++ b/lib/modules/ga_tracker.rb
@@ -1,0 +1,48 @@
+module GaTracker
+  DIMENSIONS = {
+    "IP": 1,
+    "user_id": 2,
+    "organisation_id": 3,
+    "country_iso_code": 4,
+    "method_name": 5,
+    "provider_organisation_id": 6,
+    "provider_country_iso_code": 7,
+    "request_parameters": 8,
+    "time": 9,
+    "response_time": 10,
+    "response_status": 11,
+    "failure_details": 12,
+    "timeout": 13
+  }
+  METRICS = {
+    "counter": 1
+  }
+
+  def self.add_caller_identification(hit, request, user)
+    hit.add_custom_dimension(DIMENSIONS[:IP], request.ip)
+    hit.add_custom_dimension(DIMENSIONS[:user_id], user.id)
+    hit.add_custom_dimension(DIMENSIONS[:organisation_id], user.organisation_id)
+    hit.add_custom_dimension(DIMENSIONS[:country_iso_code], user.organisation.country.iso_code2)
+  end
+
+  def self.add_request_meta_data(hit, request, action_name, params, adapter)
+    hit.add_custom_dimension(DIMENSIONS[:method_name], action_name)
+    hit.add_custom_dimension(DIMENSIONS[:provider_organisation_id], adapter.organisation_id)
+    hit.add_custom_dimension(DIMENSIONS[:provider_country_iso_code], adapter.organisation.country.iso_code2)
+    hit.add_custom_dimension(DIMENSIONS[:request_parameters], params)
+    hit.add_custom_dimension(DIMENSIONS[:time], Date.today)
+  end
+
+  def self.add_response_meta_data(hit, response, response_time, exception)
+    hit.add_custom_dimension(DIMENSIONS[:response_time], response_time)
+    hit.add_custom_dimension(DIMENSIONS[:response_status], response.status)
+    failure_details = exception.present? ? exception.message : ' '
+    hit.add_custom_dimension(DIMENSIONS[:failure_details], failure_details)
+    timeout = exception.present? ? exception.cause.is_a?(Tiemout::Error) : false
+    hit.add_custom_dimension(DIMENSIONS[:timeout], timeout)
+  end
+
+  def self.add_metrics(hit)
+    hit.add_custom_metric(METRICS[:counter], 1)
+  end
+end


### PR DESCRIPTION
This is about tracking SOAP API requests using Google Analytics.
The `staccato` gem has been installed for this purpose.
It is possible to configure the gem in the environment config file.
I've implemented a module that is responsible of keeping track of the custom dimensions and add those for each request.
At the moment I'm just using a `counter` metric, which will increase each time the same request has been made; all possible grouping across the different dimensions can be done using the Google Analytics interface.

In the GA interface some custom report tables have been created and it's possible to amend those at any time.
