### PR TITLE
Add trade reporting link

### DIFF
--- a/app/assets/stylesheets/admin/organisations.scss
+++ b/app/assets/stylesheets/admin/organisations.scss
@@ -23,6 +23,7 @@
     padding: 20px 0;
   }
   .fa { margin-right: 5px; }
-  .fa-check { color: $main-blue; }
-  .fa-times { color: $red; }
 }
+
+.fa-check { color: $main-blue; }
+.fa-times { color: $red; }

--- a/app/assets/stylesheets/admin/organisations.scss
+++ b/app/assets/stylesheets/admin/organisations.scss
@@ -25,5 +25,9 @@
   .fa { margin-right: 5px; }
 }
 
-.fa-check { color: $main-blue; }
+.fa-check, .fa-info-circle { color: $main-blue; }
 .fa-times { color: $red; }
+
+.organisation-details {
+  .fa-info-circle { margin-left: 10px; }
+}

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -41,7 +41,16 @@ class Admin::OrganisationsController < Admin::BaseController
   def update
     @organisation = Organisation.find(params[:id])
 
-    if @organisation.update_attributes(organisation_params)
+    disable_error_correction = organisation_params[:trade_reporting_enabled] == '0'
+    new_org_params = organisation_params
+
+    if disable_error_correction
+      new_org_params = organisation_params.merge({
+        trade_error_correction_in_sandbox_enabled: '0'
+      })
+    end
+
+    if @organisation.update_attributes(new_org_params)
       flash[:notice] = 'Organisation was successfully updated.'
     end
 

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -52,12 +52,12 @@ class Admin::OrganisationsController < Admin::BaseController
 
   def organisation_params
     if current_user.is_system_managers?
-      params.require(:organisation).permit(:name, :role, :country_id,
+      params.require(:organisation).permit(:name, :role, :country_id, :trade_reporting_unpermitted,
                                              adapter_attributes:
                                                [:id, :blanket_permission, countries_with_access_ids: []]
                                           )
     elsif current_user.is_cites_ma? && current_user.is_admin?
-      params.require(:organisation).permit(:name, :country_id,
+      params.require(:organisation).permit(:name, :country_id, :trade_reporting_unpermitted,
                                              adapter_attributes:
                                                [:id, :blanket_permission, countries_with_access_ids: []]
                                           )

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -52,12 +52,14 @@ class Admin::OrganisationsController < Admin::BaseController
 
   def organisation_params
     if current_user.is_system_managers?
-      params.require(:organisation).permit(:name, :role, :country_id, :trade_reporting_unpermitted,
+      params.require(:organisation).permit(:name, :role, :country_id, :trade_reporting_enabled,
+                                             :trade_error_correction_in_sandbox_enabled,
                                              adapter_attributes:
                                                [:id, :blanket_permission, countries_with_access_ids: []]
                                           )
     elsif current_user.is_cites_ma? && current_user.is_admin?
-      params.require(:organisation).permit(:name, :country_id, :trade_reporting_unpermitted,
+      params.require(:organisation).permit(:name, :country_id, :trade_reporting_enabled,
+                                             :trade_error_correction_in_sandbox_enabled,
                                              adapter_attributes:
                                                [:id, :blanket_permission, countries_with_access_ids: []]
                                           )

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -9,11 +9,11 @@ module OrganisationsHelper
     @adapter.has_country?(country.id) ? yes : no
   end
 
-  def trade_reporting_enabled?
+  def trade_reporting_enabled?(field)
     yes = content_tag(:span, '', class: 'fa fa-check')
     no = content_tag(:span, '', class: 'fa fa-times')
     return no unless @adapter
-    @organisation.trade_reporting_enabled ? yes : no
+    @organisation.send(field) ? yes : no
   end
 
   def trade_reporting_enabled_info
@@ -23,13 +23,6 @@ module OrganisationsHelper
       class: 'fa fa-info-circle',
       title: info_text
     })
-  end
-
-  def trade_error_correction_in_sandbox?
-    yes = content_tag(:span, '', class: 'fa fa-check')
-    no = content_tag(:span, '', class: 'fa fa-times')
-    return no unless @adapter
-    @organisation.trade_error_correction_in_sandbox_enabled ? yes : no
   end
 
   def trade_error_correction_info

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -8,4 +8,11 @@ module OrganisationsHelper
     return no unless @adapter
     @adapter.has_country?(country.id) ? yes : no
   end
+
+  def trade_reporting_permitted?
+    yes = content_tag(:span, '', class: 'fa fa-check')
+    no = content_tag(:span, '', class: 'fa fa-times')
+    return no unless @adapter
+    @organisation.trade_reporting_unpermitted ? no : yes
+  end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -9,10 +9,17 @@ module OrganisationsHelper
     @adapter.has_country?(country.id) ? yes : no
   end
 
-  def trade_reporting_permitted?
+  def trade_reporting_enabled?
     yes = content_tag(:span, '', class: 'fa fa-check')
     no = content_tag(:span, '', class: 'fa fa-times')
     return no unless @adapter
-    @organisation.trade_reporting_unpermitted ? no : yes
+    @organisation.trade_reporting_enabled ? yes : no
+  end
+
+  def trade_error_correction_in_sandbox?
+    yes = content_tag(:span, '', class: 'fa fa-check')
+    no = content_tag(:span, '', class: 'fa fa-times')
+    return no unless @adapter
+    @organisation.trade_error_correction_in_sandbox_enabled ? yes : no
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -16,10 +16,28 @@ module OrganisationsHelper
     @organisation.trade_reporting_enabled ? yes : no
   end
 
+  def trade_reporting_enabled_info
+    info_text = "The trade reporting module allows Parties to submit annual report trade data directly into the Trade DB, either via a web service connection or CSV upload."
+    content_tag('span', t('trade.reporting_enabled')) +
+    content_tag('i', '', {
+      class: 'fa fa-info-circle',
+      title: info_text
+    })
+  end
+
   def trade_error_correction_in_sandbox?
     yes = content_tag(:span, '', class: 'fa fa-check')
     no = content_tag(:span, '', class: 'fa fa-times')
     return no unless @adapter
     @organisation.trade_error_correction_in_sandbox_enabled ? yes : no
+  end
+
+  def trade_error_correction_info
+    info_text = "If the trade reporting mechanism detects errors in the uploaded trade data, it will suspend the submission and errors will need to be corrected. This can be done in one of 2 ways: either by applying corrections to the source permit repository, or to the uploaded copy within an online sandbox environment."
+    content_tag('span', t('trade.error_correction')) +
+    content_tag('i', '', {
+      class: 'fa fa-info-circle',
+      title: info_text
+    })
   end
 end

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -28,6 +28,14 @@
         %>
       </div>
     </div>
+    <div class="form-group">
+      <%= f.label(:trade_reporting_unpermitted, class: 'col-sm-3 control-label') { t('trade_unpermitted') } %>
+      <div class="col-sm-4">
+        <%= f.check_box :trade_reporting_unpermitted,
+           value: @trade_reporting_unpermitted, class: 'form-control'
+        %>
+      </div>
+    </div>
     <h3><%= t('adapter_show_page') %></h3>
     <%= f.fields_for :adapter do |ff| %>
       <div class="form-group">

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -30,7 +30,11 @@
     </div>
     <h3><%= t('trade_reporting_details') %></h3>
     <div class="form-group">
-      <%= f.label(:trade_reporting_enabled, class: 'col-sm-3') { t('trade.reporting_enabled') } %>
+      <%=
+        f.label(:trade_reporting_enabled, class: 'col-sm-3') {
+          trade_reporting_enabled_info
+        }
+      %>
       <div class="col-sm-4">
         <%= f.check_box :trade_reporting_enabled,
            value: @trade_reporting_enabled
@@ -40,7 +44,7 @@
     <div class="form-group">
       <%=
         f.label(:trade_error_correction_in_sandbox_enabled, class: 'col-sm-3') {
-          t('trade.error_correction')
+          trade_error_correction_info
         }
       %>
       <div class="col-sm-4">

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -28,11 +28,24 @@
         %>
       </div>
     </div>
+    <h3><%= t('trade_reporting_details') %></h3>
     <div class="form-group">
-      <%= f.label(:trade_reporting_unpermitted, class: 'col-sm-3') { t('trade_unpermitted') } %>
+      <%= f.label(:trade_reporting_enabled, class: 'col-sm-3') { t('trade.reporting_enabled') } %>
       <div class="col-sm-4">
-        <%= f.check_box :trade_reporting_unpermitted,
-           value: @trade_reporting_unpermitted
+        <%= f.check_box :trade_reporting_enabled,
+           value: @trade_reporting_enabled
+        %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%=
+        f.label(:trade_error_correction_in_sandbox_enabled, class: 'col-sm-3') {
+          t('trade.error_correction')
+        }
+      %>
+      <div class="col-sm-4">
+        <%= f.check_box :trade_error_correction_in_sandbox_enabled,
+           value: @trade_error_correction_in_sandbox
         %>
       </div>
     </div>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -29,10 +29,10 @@
       </div>
     </div>
     <div class="form-group">
-      <%= f.label(:trade_reporting_unpermitted, class: 'col-sm-3 control-label') { t('trade_unpermitted') } %>
+      <%= f.label(:trade_reporting_unpermitted, class: 'col-sm-3') { t('trade_unpermitted') } %>
       <div class="col-sm-4">
         <%= f.check_box :trade_reporting_unpermitted,
-           value: @trade_reporting_unpermitted, class: 'form-control'
+           value: @trade_reporting_unpermitted
         %>
       </div>
     </div>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -24,11 +24,15 @@
   </div>
   <div class="form-group">
     <label class='col-sm-3'><%= t('trade.reporting_enabled') %></label>
-    <span class='col-sm-5'><%= trade_reporting_enabled? %></span>
+    <span class='col-sm-5'>
+      <%= trade_reporting_enabled?("trade_reporting_enabled") %>
+    </span>
   </div>
   <div class="form-group">
     <label class='col-sm-3'><%= t('trade.error_correction') %></label>
-    <span class='col-sm-5'><%= trade_error_correction_in_sandbox? %></span>
+    <span class='col-sm-5'>
+      <%= trade_reporting_enabled?("trade_error_correction_in_sandbox_enabled") %>
+    </span>
   </div>
 </div>
 

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -23,8 +23,12 @@
     <span class='col-sm-5'><%= @organisation.country.try(:name) %></span>
   </div>
   <div class="form-group">
-    <label class='col-sm-3'><%= t('trade_unpermitted') %></label>
-    <span class='col-sm-5'><%= trade_reporting_permitted? %></span>
+    <label class='col-sm-3'><%= t('trade.reporting_enabled') %></label>
+    <span class='col-sm-5'><%= trade_reporting_enabled? %></span>
+  </div>
+  <div class="form-group">
+    <label class='col-sm-3'><%= t('trade.error_correction') %></label>
+    <span class='col-sm-5'><%= trade_error_correction_in_sandbox? %></span>
   </div>
 </div>
 

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -22,6 +22,10 @@
     <label class='col-sm-3'><%= t('organisation_country') %></label>
     <span class='col-sm-5'><%= @organisation.country.try(:name) %></span>
   </div>
+  <div class="form-group">
+    <label class='col-sm-3'><%= t('trade_unpermitted') %></label>
+    <span class='col-sm-5'><%= trade_reporting_permitted? %></span>
+  </div>
 </div>
 
 <% if @adapter %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,7 +17,7 @@
             class: (current_page?(permits_path) ? 'active' : nil)
           %>
         </li>
-        <% if current_user && !current_user.organisation.trade_reporting_unpermitted %>
+        <% if current_user && current_user.organisation.trade_reporting_enabled %>
           <li class="nav-elem">
             <%=
               link_to "Trade Reporting Tool",

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,12 +17,14 @@
             class: (current_page?(permits_path) ? 'active' : nil)
           %>
         </li>
-        <li class="nav-elem">
-          <%=
-            link_to "Trade Reporting Tool",
-              "#{Rails.application.secrets.trade_reporting_tool['sign_in']}?user=#{current_user.email}"
-          %>
-        </li>
+        <% if current_user && !current_user.organisation.trade_reporting_unpermitted %>
+          <li class="nav-elem">
+            <%=
+              link_to "Trade Reporting Tool",
+                "#{Rails.application.secrets.trade_reporting_tool['sign_in']}?user=#{current_user.email}"
+            %>
+          </li>
+        <% end %>
         <li class="nav-elem"><a href="#"><%= t('about') %></a></li>
       </ul>
     </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,6 +17,12 @@
             class: (current_page?(permits_path) ? 'active' : nil)
           %>
         </li>
+        <li class="nav-elem">
+          <%=
+            link_to "Trade Reporting Tool",
+              "#{Rails.application.secrets.trade_reporting_tool['sign_in']}?user=#{current_user.email}"
+          %>
+        </li>
         <li class="nav-elem"><a href="#"><%= t('about') %></a></li>
       </ul>
     </nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,5 +116,5 @@ en:
   issued: "Issued by"
   trade:
     reporting_details: "Trade reporting details"
-    reporting_enabled: "Trade reporting"
+    reporting_enabled: "Trade reporting enabled"
     error_correction: "Trade error correction in online sandbox"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,3 +114,4 @@ en:
   address: "Adress"
   country: "Country"
   issued: "Issued by"
+  trade_unpermitted: "Trade reporting permitted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,4 +114,7 @@ en:
   address: "Adress"
   country: "Country"
   issued: "Issued by"
-  trade_unpermitted: "Trade reporting permitted"
+  trade:
+    reporting_details: "Trade reporting details"
+    reporting_enabled: "Trade reporting"
+    error_correction: "Trade error correction in online sandbox"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,6 +7,9 @@ default: &default
     password: <%= ENV["MAILER_PASSWORD"] %>
     host: <%= ENV["MAILER_HOST"] %>
     from: <%= ENV["MAILER_FROM"] %>
+  trade_reporting_tool:
+    host: <%= ENV["TRADE_REPORTING_HOST"] %>
+    sign_in: <%= ENV["TRADE_REPORTING_SIGN_IN"] %>
 
 production_and_staging: &production_and_staging
   <<: *default

--- a/db/migrate/20161102160102_add_trade_reporting_details_fields_to_organisations.rb
+++ b/db/migrate/20161102160102_add_trade_reporting_details_fields_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddTradeReportingDetailsFieldsToOrganisations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organisations, :trade_reporting_enabled, :boolean, default: false
+    add_column :organisations, :trade_error_correction_in_sandbox_enabled, :boolean, default: false
+  end
+end

--- a/db/migrate/20161102160102_add_trade_reporting_unpermitted_field_to_organisations.rb
+++ b/db/migrate/20161102160102_add_trade_reporting_unpermitted_field_to_organisations.rb
@@ -1,5 +1,0 @@
-class AddTradeReportingUnpermittedFieldToOrganisations < ActiveRecord::Migration[5.0]
-  def change
-    add_column :organisations, :trade_reporting_unpermitted, :boolean, default: false
-  end
-end

--- a/db/migrate/20161102160102_add_trade_reporting_unpermitted_field_to_organisations.rb
+++ b/db/migrate/20161102160102_add_trade_reporting_unpermitted_field_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddTradeReportingUnpermittedFieldToOrganisations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organisations, :trade_reporting_unpermitted, :boolean, default: false
+  end
+end

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Admin::OrganisationsController, type: :controller do
         expect(organisation.role).to eq(Organisation::SYSTEM_MANAGERS)
         expect(response.status).to eq(302)
       end
+
+      it "disables trade error correction if reporting is disabled" do
+        organisation = FactoryGirl.create(:cites_ma, {
+          trade_reporting_enabled: true,
+          trade_error_correction_in_sandbox_enabled: true
+        })
+        patch :update, params: {
+          id: organisation.id, organisation: {
+            role: Organisation::SYSTEM_MANAGERS, trade_reporting_enabled: '0'
+          }
+        }
+        organisation.reload
+        expect(organisation.trade_error_correction_in_sandbox_enabled).to eq(false)
+        expect(response.status).to eq(302)
+      end
     end
   end
 


### PR DESCRIPTION
Adds link to trade reporting in the EPIX main nav bar.
Checkbox in organisation's settings page to opt out; if ticked, do not display the 'trade reporting' link.

Migration required.