### PR TITLE
Add input field for token

### DIFF
--- a/app/controllers/permits_controller.rb
+++ b/app/controllers/permits_controller.rb
@@ -8,7 +8,8 @@ class PermitsController < ApplicationController
   def index
     if @country && @permit_identifier
       redirect_to(permit_path(
-        country: @country, permit_identifier: @permit_identifier
+        country: @country, permit_identifier: @permit_identifier,
+        security_token: @security_token
       )) && return
     end
     @countries = Organisation.cites_mas.with_available_adapters.
@@ -21,7 +22,7 @@ class PermitsController < ApplicationController
     @response = Adapters::SimpleAdapter.run(
       @adapter, {
         CertificateNumber: @permit_identifier,
-        TokenId: '?',
+        TokenId: @security_token,
         IsoCountryCode: @country
       }
     )
@@ -39,6 +40,7 @@ class PermitsController < ApplicationController
   def sanitise_params
     @country = params[:country] && params[:country].strip[0..1]
     @permit_identifier = params[:permit_identifier]
+    @security_token = params[:security_token]
   end
 
   def load_adapter

--- a/app/views/permits/index.html.erb
+++ b/app/views/permits/index.html.erb
@@ -17,6 +17,13 @@
         {class: 'form-control', placeholder: t('permit_identifier'), required: true}
       )%>
     </div>
+    <div class="form-group">
+      <%= label_tag(:security_token, t('enter_security_token')) %>
+      <%= text_field_tag(
+        :security_token, nil,
+        {class: 'form-control', placeholder: t('security_token'), required: true })
+      %>
+    </div>
     <div class="form-group text-center">
       <%= submit_tag(t('search_button_label'), class: 'button search-button') %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
   select_country: 'Please select country'
   enter_permit_identifier: 'Enter permit identifier'
   permit_identifier: 'Permit identifier'
+  enter_security_token: 'Enter security token'
+  security_token: 'Security token'
   search_button_label: 'Search'
   my_account: 'My account'
   my_organisation: 'My organisation'


### PR DESCRIPTION
Adds a text input field in the permit search page for a security token.
The security token is also passed across the index and show actions in the controller.