### PR TITLE
Fix input for token

### DIFF
--- a/app/assets/stylesheets/application/permit.scss
+++ b/app/assets/stylesheets/application/permit.scss
@@ -222,3 +222,7 @@ input.permit-check:checked ~ span {
   padding-top: 15px;
   border-top: 1px solid $light-grey;
 }
+
+.security-token-label {
+  i { margin-left: 5px; }
+}

--- a/app/helpers/permits_helper.rb
+++ b/app/helpers/permits_helper.rb
@@ -1,0 +1,10 @@
+module PermitsHelper
+  TOKEN_INFO =
+    'Please fill in for permit numbers protected by an additional security code.'
+  def security_token_label
+    label_tag(:security_token, class: 'security-token-label') do
+      content_tag(:span, t('enter_security_token')) +
+      content_tag(:i, ' ', class: 'fa fa-info-circle blue', title: TOKEN_INFO)
+    end
+  end
+end

--- a/app/helpers/permits_helper.rb
+++ b/app/helpers/permits_helper.rb
@@ -1,10 +1,8 @@
 module PermitsHelper
-  TOKEN_INFO =
-    'Please fill in for permit numbers protected by an additional security code.'
   def security_token_label
     label_tag(:security_token, class: 'security-token-label') do
       content_tag(:span, t('enter_security_token')) +
-      content_tag(:i, ' ', class: 'fa fa-info-circle blue', title: TOKEN_INFO)
+      content_tag(:i, ' ', class: 'fa fa-info-circle blue', title: t('token_info'))
     end
   end
 end

--- a/app/views/permits/index.html.erb
+++ b/app/views/permits/index.html.erb
@@ -18,7 +18,7 @@
       )%>
     </div>
     <div class="form-group">
-      <%= label_tag(:security_token, t('enter_security_token')) %>
+      <%= security_token_label %>
       <%= text_field_tag(
         :security_token, nil,
         {class: 'form-control', placeholder: t('security_token')}

--- a/app/views/permits/index.html.erb
+++ b/app/views/permits/index.html.erb
@@ -21,8 +21,8 @@
       <%= label_tag(:security_token, t('enter_security_token')) %>
       <%= text_field_tag(
         :security_token, nil,
-        {class: 'form-control', placeholder: t('security_token'), required: true })
-      %>
+        {class: 'form-control', placeholder: t('security_token')}
+      )%>
     </div>
     <div class="form-group text-center">
       <%= submit_tag(t('search_button_label'), class: 'button search-button') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
   permit_identifier: 'Permit identifier'
   enter_security_token: 'Enter security token'
   security_token: 'Security token'
+  token_info: 'Please fill in for permit numbers protected by an additional security code.'
   search_button_label: 'Search'
   my_account: 'My account'
   my_organisation: 'My organisation'


### PR DESCRIPTION
Security token when searching for permits to be optional and to display info.
[PT story](https://www.pivotaltracker.com/story/show/135130701)